### PR TITLE
BindingMapper

### DIFF
--- a/finat/ast.py
+++ b/finat/ast.py
@@ -184,7 +184,9 @@ class ForAll(StringifyMixin, p._MultiChildExpression):
     """
     def __init__(self, indices, body):
 
-        self.children = (tuple(indices), body)
+        self.indices = indices
+        self.body = body
+        self.children = (self.indices, self.body)
         self._color = "blue"
 
     def __getinitargs__(self):

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -154,6 +154,9 @@ class ScalarElementMixin(object):
 
         expr = psi * phi * w[p__]
 
+        if d:
+            expr = IndexSum(d, expr)
+
         if pullback:
             expr *= Abs(kernel_data.detJ)
 

--- a/finat/geometry_mapper.py
+++ b/finat/geometry_mapper.py
@@ -76,8 +76,8 @@ class GeometryMapper(IdentityMapper):
         element = kd.coordinate_element
         J = element.field_evaluation(phi_x, q, kd, grad, pullback=False)
 
-        inner_lets = (((kd.detJ, Det(kd.J)),) if kd.detJ in self.local_geometry else () +
-                      ((kd.invJ, Inverse(kd.J)),) if kd.invJ in self.local_geometry else ())
+        inner_lets = ((kd.detJ, Det(kd.J)),) if kd.detJ in self.local_geometry else ()
+        inner_lets += ((kd.invJ, Inverse(kd.J)),) if kd.invJ in self.local_geometry else ()
 
         # The local geometry goes out of scope at this point.
         self.local_geometry = set()

--- a/finat/interpreter.py
+++ b/finat/interpreter.py
@@ -282,6 +282,10 @@ class FinatEvaluationMapper(FloatEvaluationMapper):
 
         return abs(self.rec(expr.expression))
 
+    def map_inverse(self, expr):
+
+        return np.linalg.inv(self.rec(expr.expression))
+
 
 def evaluate(expression, context={}, kernel_data=None):
     """Take a FInAT expression and a set of definitions for undefined

--- a/finat/interpreter.py
+++ b/finat/interpreter.py
@@ -2,6 +2,7 @@
 performant, but rather to provide a test facility for FInAT code."""
 import pymbolic.primitives as p
 from pymbolic.mapper.evaluator import FloatEvaluationMapper, UnknownVariableError
+from .mappers import BindingMapper
 from ast import IndexSum, ForAll, LeviCivita, FInATSyntaxError
 from indices import TensorPointIndex
 import numpy as np
@@ -44,17 +45,7 @@ class FinatEvaluationMapper(FloatEvaluationMapper):
     def map_recipe(self, expr):
         """Evaluate expr for all values of free indices"""
 
-        d, b, p = expr.indices
-
-        free_indices = tuple([i for i in d + b + p if i not in self.indices])
-
-        try:
-            forall = ForAll(free_indices, expr.body)
-            return self.rec(forall)
-        except:
-            if hasattr(forall, "_error"):
-                expr.set_error()
-            raise
+        return self.rec(expr.body)
 
     def map_index_sum(self, expr):
 
@@ -300,6 +291,7 @@ def evaluate(expression, context={}, kernel_data=None):
             context[var[0].name] = var[1]()
 
     try:
+        expression = BindingMapper(context)(expression)
         return FinatEvaluationMapper(context)(expression)
     except:
         print expression

--- a/finat/interpreter.py
+++ b/finat/interpreter.py
@@ -46,7 +46,7 @@ class FinatEvaluationMapper(FloatEvaluationMapper):
 
         d, b, p = expr.indices
 
-        free_indices = [i for i in d + b + p if i not in self.indices]
+        free_indices = tuple([i for i in d + b + p if i not in self.indices])
 
         try:
             forall = ForAll(free_indices, expr.body)

--- a/finat/mappers.py
+++ b/finat/mappers.py
@@ -224,5 +224,14 @@ class BindingMapper(IdentityMapper):
         body = self.rec(expr.body)
         for idx in indices:
             self.bound_above.remove(idx)
-            self.bound_below.add(idx)
         return IndexSum(indices, body)
+
+    def map_for_all(self, expr):
+        indices = expr.indices
+        for idx in indices:
+            self.bound_above.add(idx)
+        body = self.rec(expr.body)
+        for idx in indices:
+            self.bound_above.remove(idx)
+            self.bound_below.add(idx)
+        return ForAll(indices, body)

--- a/finat/mappers.py
+++ b/finat/mappers.py
@@ -67,6 +67,8 @@ class _StringifyMapper(StringifyMapper):
                            self.rec(expr.indices, PREC_NONE, indent=indent, *args, **kwargs),
                            self.rec(expr.body, PREC_NONE, indent=indent, *args, **kwargs))
 
+    map_for_all = map_recipe
+
     def map_let(self, expr, enclosing_prec, indent=None, *args, **kwargs):
         if indent is None:
             fmt = expr.name + "(%s, %s)"


### PR DESCRIPTION
This merge adds a simple mapper that inserts `ForAlls` for any unbound indices in a `Recipe`. The interpreter now invokes this mapper before evaluating a `Recipe` instead of adding implicit `ForAlls` during evaluation. The merge also includes various bugfixes.