### PR TITLE
Coffee RHS assembly

### DIFF
--- a/finat/coffee_compiler.py
+++ b/finat/coffee_compiler.py
@@ -88,7 +88,7 @@ class CoffeeMapper(CombineMapper):
         return determinant[e.shape[0]](self.rec(e))
 
     def map_abs(self, expr):
-        return self.rec(expr.expression)
+        return coffee.FunCall("fabs", self.rec(expr.expression))
 
     def map_for_all(self, expr):
         var = coffee.Symbol(self.scope_var[-1], self.rec(expr.indices))
@@ -176,7 +176,7 @@ class CoffeeKernel(Kernel):
 
         return coffee.FunDecl("void", "coffee_kernel", args_ast,
                               coffee.Block(body_ast),
-                              headers=["stdio.h"])
+                              headers=["math.h", "string.h"])
 
 
 def evaluate(expression, context={}, kernel_data=None):

--- a/finat/coffee_compiler.py
+++ b/finat/coffee_compiler.py
@@ -16,9 +16,9 @@ from pprint import pformat
 from collections import deque
 
 
-determinant = {1: lambda e: coffee.Det1(e),
-               2: lambda e: coffee.Det2(e),
-               3: lambda e: coffee.Det3(e)}
+determinant = {1: lambda e: coffee.Determinant1x1(e),
+               2: lambda e: coffee.Determinant2x2(e),
+               3: lambda e: coffee.Determinant3x3(e)}
 
 
 class CoffeeMapper(CombineMapper):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ pytest-pep8
 git+https://github.com/inducer/pymbolic.git
 numpy>=1.6.1
 sympy
-git+https://github.com/coneoproject/COFFEE.git@det-kernels
+git+https://github.com/coneoproject/COFFEE.git


### PR DESCRIPTION
This merge adds the final pieces for RHS assembly via FInAT and Coffee through the Firedrake `finat_loop` interface. The generated kernel code is functional for Lagrange elements with geometry and `grad` derivatives, although it is not yet optimised and currently only supports RHS assembly due to double indirections in the kernel signatures.