### PR TITLE
Index permuation

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -6,6 +6,8 @@ from product_elements import ScalarProductElement
 from points import PointSet
 from utils import KernelData, Kernel
 from derivatives import div, grad, curl
+from indices import *
+from ast import *
 import interpreter
 import quadrature
 import ufl_interface

--- a/finat/ast.py
+++ b/finat/ast.py
@@ -74,15 +74,16 @@ class Recipe(StringifyMixin, p.Expression):
         the second is a tuple of :class:`BasisFunctionIndex`, and
         the third is a tuple of :class:`PointIndex`.
         Any of the tuples may be empty.
-    :param expression: The expression returned by this :class:`Recipe`.
+    :param body: The expression returned by this :class:`Recipe`.
     """
-    def __init__(self, indices, body):
+    def __init__(self, indices, body, _transpose=None):
         try:
             assert len(indices) == 3
         except:
             raise FInATSyntaxError("Indices must be a triple of tuples")
         self.indices = tuple(indices)
         self.body = body
+        self._transpose = _transpose
         self._color = "blue"
 
     mapper_method = "map_recipe"

--- a/finat/ast.py
+++ b/finat/ast.py
@@ -8,6 +8,10 @@ except ImportError:
     def colored(string, color, attrs=[]):
         return string
 
+__all__ = ["Variable", "Array", "Recipe", "IndexSum", "LeviCivita",
+           "ForAll", "Wave", "Let", "Delta", "Inverse", "Det", "Abs",
+           "CompoundVector"]
+
 
 class FInATSyntaxError(Exception):
     """Exception to raise when users break the rules of the FInAT ast."""

--- a/finat/coffee_compiler.py
+++ b/finat/coffee_compiler.py
@@ -9,7 +9,7 @@ import os
 import subprocess
 import ctypes
 import numpy as np
-from .utils import Kernel
+from .utils import Kernel, KernelData
 from .ast import Recipe, IndexSum, Array, Inverse
 from .mappers import BindingMapper, IndexSumMapper
 from pprint import pformat
@@ -193,6 +193,9 @@ class CoffeeKernel(Kernel):
 def evaluate(expression, context={}, kernel_data=None):
     index_shape = ()
     args_data = []
+
+    if not kernel_data:
+        kernel_data = KernelData()
 
     # Pack free indices as kernel arguments
     for index in expression.indices:

--- a/finat/indices.py
+++ b/finat/indices.py
@@ -3,6 +3,11 @@ import pymbolic.primitives as p
 from pymbolic.mapper.stringifier import StringifyMapper
 import math
 
+__all__ = ["PointIndex", "TensorPointIndex", "BasisFunctionIndex",
+           "TensorBasisFunctionIndex",
+           "SimpliciallyGradedBasisFunctionIndex",
+           "DimensionIndex"]
+
 
 class IndexBase(ast.Variable):
     '''Base class for symbolic index objects.'''

--- a/finat/interpreter.py
+++ b/finat/interpreter.py
@@ -45,7 +45,10 @@ class FinatEvaluationMapper(FloatEvaluationMapper):
     def map_recipe(self, expr):
         """Evaluate expr for all values of free indices"""
 
-        return self.rec(expr.body)
+        if expr._transpose:
+            return self.rec(expr.body).transpose(expr._transpose)
+        else:
+            return self.rec(expr.body)
 
     def map_index_sum(self, expr):
 

--- a/finat/mappers.py
+++ b/finat/mappers.py
@@ -1,3 +1,4 @@
+from collections import deque
 from pymbolic.mapper import IdentityMapper as IM
 from pymbolic.mapper.stringifier import StringifyMapper, PREC_NONE
 from pymbolic.mapper import WalkMapper as WM
@@ -15,18 +16,19 @@ class IdentityMapper(IM):
     def __init__(self):
         super(IdentityMapper, self).__init__()
 
-    def map_recipe(self, expr, *args):
-        return expr.__class__(self.rec(expr.indices, *args),
-                              self.rec(expr.body, *args))
+    def map_recipe(self, expr, *args, **kwargs):
+        return expr.__class__(self.rec(expr.indices, *args, **kwargs),
+                              self.rec(expr.body, *args, **kwargs))
 
-    def map_index(self, expr, *args):
+    def map_index(self, expr, *args, **kwargs):
         return expr
 
-    def map_delta(self, expr, *args):
-        return expr.__class__(*(self.rec(c, *args) for c in expr.children))
+    def map_delta(self, expr, *args, **kwargs):
+        return expr.__class__(*(self.rec(c, *args, **kwargs)
+                                for c in expr.children))
 
-    def map_inverse(self, expr, *args):
-        return expr.__class__(self.rec(expr.expression, *args))
+    def map_inverse(self, expr, *args, **kwargs):
+        return expr.__class__(self.rec(expr.expression, *args, **kwargs))
 
     map_let = map_delta
     map_for_all = map_delta
@@ -44,7 +46,7 @@ class _IndexMapper(IdentityMapper):
 
         self.replacements = replacements
 
-    def map_index(self, expr, *args):
+    def map_index(self, expr, *args, **kwargs):
         '''Replace indices if they are in the replacements list'''
 
         try:
@@ -200,16 +202,31 @@ class BindingMapper(IdentityMapper):
         :arg context: a mapping from variable names to values
         """
         super(BindingMapper, self).__init__()
-        self.bound_above = set()
-        self.bound_below = set()
 
-    def map_recipe(self, expr):
-        body = self.rec(expr.body)
+    def map_recipe(self, expr, bound_above=None, bound_below=None):
+        if bound_above is None:
+            bound_above = set()
+        if bound_below is None:
+            bound_below = deque()
+
+        body = self.rec(expr.body, bound_above, bound_below)
 
         d, b, p = expr.indices
-        free_indices = tuple([i for i in d + b + p
-                              if i not in self.bound_below and
-                              i not in self.bound_above])
+        recipe_indices = tuple([i for i in d + b + p
+                                if i not in bound_above])
+        free_indices = tuple([i for i in recipe_indices
+                              if i not in bound_below])
+
+        bound_below.extendleft(reversed(free_indices))
+        # Calculate the permutation from the order of loops actually
+        # employed to the ordering of indices in the Recipe.
+        try:
+            transpose = [recipe_indices.index(i) for i in bound_below]
+        except ValueError:
+            print "recipe_indices", recipe_indices
+            print "missing index", i
+            i.set_error()
+            raise
 
         if len(free_indices) > 0:
             expr = Recipe(expr.indices, ForAll(free_indices, body))
@@ -218,23 +235,32 @@ class BindingMapper(IdentityMapper):
 
         return expr
 
-    def map_index_sum(self, expr):
+    def map_let(self, expr, bound_above, bound_below):
+
+        # Indices bound in the Let bindings should not count as
+        # bound_below for nodes higher in the tree.
+        return Let(tuple((symbol, self.rec(letexpr, bound_above,
+                                           bound_below=None))
+                         for symbol, letexpr in expr.bindings),
+                   self.rec(expr.body, bound_above, bound_below))
+
+    def map_index_sum(self, expr, bound_above, bound_below):
         indices = expr.indices
         for idx in indices:
-            self.bound_above.add(idx)
-        body = self.rec(expr.body)
+            bound_above.add(idx)
+        body = self.rec(expr.body, bound_above, bound_below)
         for idx in indices:
-            self.bound_above.remove(idx)
+            bound_above.remove(idx)
         return IndexSum(indices, body)
 
-    def map_for_all(self, expr):
+    def map_for_all(self, expr, bound_above, bound_below):
         indices = expr.indices
         for idx in indices:
-            self.bound_above.add(idx)
-        body = self.rec(expr.body)
+            bound_above.add(idx)
+        body = self.rec(expr.body, bound_above, bound_below)
         for idx in indices:
-            self.bound_above.remove(idx)
-            self.bound_below.add(idx)
+            bound_above.remove(idx)
+            bound_below.appendleft(idx)
         return ForAll(indices, body)
 
 

--- a/finat/utils.py
+++ b/finat/utils.py
@@ -15,7 +15,8 @@ class Kernel(object):
 
 
 class KernelData(object):
-    def __init__(self, coordinate_element, coordinate_var=None, affine=None):
+    def __init__(self, coordinate_element=None, coordinate_var=None,
+                 affine=None):
         """
         :param coordinate_element: the (vector-valued) finite element for
             the coordinate field.
@@ -29,7 +30,7 @@ class KernelData(object):
 
         self.coordinate_element = coordinate_element
         self.coordinate_var = coordinate_var
-        if affine is None:
+        if affine is None and coordinate_element:
             self.affine = coordinate_element.degree <= 1 and \
                 isinstance(coordinate_element.cell, _simplex)
         else:
@@ -42,9 +43,11 @@ class KernelData(object):
         self.variables = set()
 
         #: The geometric dimension of the physical space.
-        self.gdim = coordinate_element._dimension
+        self.gdim = (coordinate_element._dimension
+                     if coordinate_element else None)
         #: The topological dimension of the reference element
-        self.tdim = coordinate_element._cell.get_spatial_dimension()
+        self.tdim = (coordinate_element._cell.get_spatial_dimension()
+                     if coordinate_element else None)
 
         self._variable_count = 0
         self._point_count = 0

--- a/tests/test_index_permutation.py
+++ b/tests/test_index_permutation.py
@@ -2,7 +2,6 @@ import pytest
 import finat
 
 
-@pytest.mark.xfail
 def test_index_permuation():
 
     i = finat.DimensionIndex(3)

--- a/tests/test_index_permutation.py
+++ b/tests/test_index_permutation.py
@@ -1,0 +1,17 @@
+import pytest
+import finat
+
+
+@pytest.mark.xfail
+def test_index_permuation():
+
+    i = finat.DimensionIndex(3)
+    j = finat.DimensionIndex(2)
+
+    recipe = finat.Recipe(((i, j), (), ()),
+                          finat.ForAll((j,),
+                                       finat.ForAll((i,), 1.)))
+
+    out = finat.interpreter.evaluate(recipe)
+
+    assert out.shape == (3, 2)

--- a/tests/test_index_permutation.py
+++ b/tests/test_index_permutation.py
@@ -15,3 +15,18 @@ def test_index_permuation():
     out = finat.interpreter.evaluate(recipe)
 
     assert out.shape == (3, 2)
+
+
+@pytest.mark.xfail
+def test_index_permuation_coffee():
+
+    i = finat.DimensionIndex(3)
+    j = finat.DimensionIndex(2)
+
+    recipe = finat.Recipe(((i, j), (), ()),
+                          finat.ForAll((j,),
+                                       finat.ForAll((i,), 1.)))
+
+    out = finat.coffee_compiler.evaluate(recipe)
+
+    assert out.shape == (3, 2)


### PR DESCRIPTION
This branch deals with the fact that the order of the ForAll statements may not correspond with the order in which the indices occur in Recipes. Recipe objects now record the required generalised transpose and the interpreter honours this.

As part of this work, the BindingMapper is now stateless and passes binding information as arguments rather than as attributes of the mapper object.

There is an xfailing test for the coffee compiler which highlights that this fix has not been applied there yet. That xfailing test highlights a further issue with the coffee compiler's handing of multiple ForAll statements.