### PR TITLE
Report if basis functions are cellwise constant

### DIFF
--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -45,23 +45,20 @@ class FiatElementBase(FiniteElementBase):
         # Work out the correct transposition between FIAT storage and ours.
         tr = (2, 0, 1) if self.value_shape else (1, 0)
 
-        # Convert the FIAT tabulation into a gem tensor. Note that
-        # this does not exploit the symmetry of the derivative tensor.
         if derivative:
             e = np.eye(dim, dtype=np.int)
             tensor = np.empty((dim,) * derivative, dtype=np.object)
             it = np.nditer(tensor, flags=['multi_index', 'refs_ok'], op_flags=["writeonly"])
             while not it.finished:
                 derivative_multi_index = tuple(e[it.multi_index, :].sum(0))
-                it[0] = gem.Literal(restore_shape(fiat_tab[derivative_multi_index].transpose(tr), ps))
+                it[0] = gem.Indexed(gem.Literal(restore_shape(fiat_tab[derivative_multi_index].transpose(tr), ps)),
+                                    pi + i + vi)
                 it.iternext()
-            tensor = gem.ListTensor(tensor)
+            tensor = gem.Indexed(gem.ListTensor(tensor), di)
         else:
-            tensor = gem.Literal(restore_shape(fiat_tab[(0,) * dim].transpose(tr), ps))
+            tensor = gem.Indexed(gem.Literal(restore_shape(fiat_tab[(0,) * dim].transpose(tr), ps)), pi + i + vi)
 
-        return gem.ComponentTensor(gem.Indexed(tensor,
-                                               di + pi + i + vi),
-                                   i + vi + di)
+        return gem.ComponentTensor(tensor, i + vi + di)
 
     @property
     def entity_dofs(self):

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -45,18 +45,19 @@ class FiatElementBase(FiniteElementBase):
         # Work out the correct transposition between FIAT storage and ours.
         tr = (2, 0, 1) if self.value_shape else (1, 0)
 
+        e = np.eye(dim, dtype=np.int)
+        tensor = np.empty((dim,) * derivative, dtype=np.object)
+        it = np.nditer(tensor, flags=['multi_index', 'refs_ok'], op_flags=["writeonly"])
+        while not it.finished:
+            derivative_multi_index = tuple(e[it.multi_index, :].sum(0))
+            it[0] = gem.Indexed(gem.Literal(restore_shape(fiat_tab[derivative_multi_index].transpose(tr), ps)),
+                                pi + i + vi)
+            it.iternext()
+
         if derivative:
-            e = np.eye(dim, dtype=np.int)
-            tensor = np.empty((dim,) * derivative, dtype=np.object)
-            it = np.nditer(tensor, flags=['multi_index', 'refs_ok'], op_flags=["writeonly"])
-            while not it.finished:
-                derivative_multi_index = tuple(e[it.multi_index, :].sum(0))
-                it[0] = gem.Indexed(gem.Literal(restore_shape(fiat_tab[derivative_multi_index].transpose(tr), ps)),
-                                    pi + i + vi)
-                it.iternext()
             tensor = gem.Indexed(gem.ListTensor(tensor), di)
         else:
-            tensor = gem.Indexed(gem.Literal(restore_shape(fiat_tab[(0,) * dim].transpose(tr), ps)), pi + i + vi)
+            tensor = tensor[()]
 
         return gem.ComponentTensor(tensor, i + vi + di)
 

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -61,7 +61,7 @@ class FiatElementBase(FiniteElementBase):
 
         return gem.ComponentTensor(gem.Indexed(tensor,
                                                di + pi + i + vi),
-                                   pi + i + vi + di)
+                                   i + vi + di)
 
     @property
     def entity_dofs(self):

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -108,16 +108,3 @@ class TensorPointSet(AbstractPointSet):
 # class GaussLobattoPointSet(PointSet):
 #     """A set of 1D Gauss Lobatto points. This is a separate class in order
 #     to allow elements to apply spectral element tricks."""
-
-
-def restore_shape(array, ps):
-    """Restores the shape of a point set for a numpy array.
-
-    :arg array: numpy array of arbitrary rank with the first dimension
-                representing the points.
-    :arg ps: point set object
-    :returns: reshaped numpy array with the first dimension replaced
-              with the shape of the point set.
-    """
-    shape = tuple(index.extent for index in ps.indices)
-    return array.reshape(shape + array.shape[1:])

--- a/finat/tensorfiniteelement.py
+++ b/finat/tensorfiniteelement.py
@@ -69,7 +69,7 @@ class TensorFiniteElement(FiniteElementBase):
         indices = tuple(gem.Index() for i in scalarbasis.shape)
 
         # Work out which of the indices are for what.
-        pi = len(ps.indices) + len(self._base_element.index_shape)
+        pi = len(self._base_element.index_shape)
         d = derivative
 
         # New basis function and value indices.


### PR DESCRIPTION
This change makes FInAT report if a basis function is cellwise constant, so TSFC can optimise evaluation. This is achieved through an **API change**:

`basis_evaluation` no longer returns point structure as shape, but rather as free indices. If the value of the basis functions does not depend on some point indices, then those indices simply won't appear in the free indices of the return expression.