### PR TITLE
Add QuadratureElement

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -7,4 +7,5 @@ from .fiat_elements import Nedelec, NedelecSecondKind, Regge  # noqa: F401
 from .tensorfiniteelement import TensorFiniteElement  # noqa: F401
 from .tensor_product import TensorProductElement  # noqa: F401
 from .quadrilateral import QuadrilateralElement  # noqa: F401
+from .quadrature_element import QuadratureElement  # noqa: F401
 from . import quadrature  # noqa: F401

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, print_function, division
 from six import with_metaclass
-from six.moves import range
+from six.moves import range, zip
 
 from abc import ABCMeta, abstractproperty
 from itertools import chain, product
@@ -57,6 +57,12 @@ class PointSet(AbstractPointSet):
     def expression(self):
         return gem.partial_indexed(gem.Literal(self.points), self.indices)
 
+    def almost_equal(self, other, tolerance=1e-12):
+        """Approximate numerical equality of point sets"""
+        return type(self) == type(other) and \
+            self.points.shape == other.points.shape and \
+            numpy.allclose(self.points, other.points, rtol=0, atol=tolerance)
+
 
 class TensorPointSet(AbstractPointSet):
 
@@ -80,3 +86,9 @@ class TensorPointSet(AbstractPointSet):
             for i in range(point_set.dimension):
                 result.append(gem.Indexed(point_set.expression, (i,)))
         return gem.ListTensor(result)
+
+    def almost_equal(self, other, tolerance=1e-12):
+        """Approximate numerical equality of point sets"""
+        return type(self) == type(other) and \
+            len(self.factors) == len(other.factors) and \
+            all(s.almost_equal(o) for s, o in zip(self.factors, other.factors))

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -91,4 +91,5 @@ class TensorPointSet(AbstractPointSet):
         """Approximate numerical equality of point sets"""
         return type(self) == type(other) and \
             len(self.factors) == len(other.factors) and \
-            all(s.almost_equal(o) for s, o in zip(self.factors, other.factors))
+            all(s.almost_equal(o, tolerance=tolerance)
+                for s, o in zip(self.factors, other.factors))

--- a/finat/quadrature_element.py
+++ b/finat/quadrature_element.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import, print_function, division
+from six import iteritems
+from six.moves import range, zip
+from functools import reduce
+
+import numpy
+
+import gem
+from gem.utils import cached_property
+
+from finat.finiteelementbase import FiniteElementBase
+from finat.quadrature import make_quadrature
+
+
+class QuadratureElement(FiniteElementBase):
+    """A set of quadrature points pretending to be a finite element."""
+
+    def __init__(self, cell, degree, scheme="default"):
+        self.cell = cell
+        self._rule = make_quadrature(cell, degree, scheme)
+
+    @cached_property
+    def cell(self):
+        pass  # set at initialisation
+
+    @property
+    def degree(self):
+        raise NotImplementedError("QuadratureElement does not represent a polynomial space.")
+
+    @cached_property
+    def _entity_dofs(self):
+        # Inspired by ffc/quadratureelement.py
+        entity_dofs = {
+            {entity: [] for entity in entities}
+            for dim, entities in iteritems(self.cell.get_topology())
+        }
+        entity_dofs[self.cell.get_dimension()] = {0: list(range(self.space_dimension()))}
+        return entity_dofs
+
+    def entity_dofs(self):
+        return self._entity_dofs
+
+    def space_dimension(self):
+        return numpy.prod(self.index_shape, dtype=int)
+
+    @property
+    def index_shape(self):
+        ps = self._rule.point_set
+        return tuple(index.extent for index in ps.indices)
+
+    @property
+    def value_shape(self):
+        return ()
+
+    def basis_evaluation(self, order, ps, entity=None):
+        '''Return code for evaluating the element at known points on the
+        reference element.
+
+        :param order: return derivatives up to this order.
+        :param ps: the point set object.
+        :param entity: the cell entity on which to tabulate.
+        '''
+        if entity is not None and entity != (self.cell.get_dimension(), 0):
+            raise ValueError('QuadratureElement does not "tabulate" on subentities.')
+
+        if order:
+            raise ValueError("Derivatives are not defined on a QuadratureElement.")
+
+        if not self._rule.point_set.almost_equal(ps):
+            raise ValueError("Mismatch of quadrature points!")
+
+        # Return an outer product of identity matrices
+        multiindex = self.get_indices()
+        product = reduce(gem.Product, [gem.Delta(q, r)
+                                       for q, r in zip(ps.indices, multiindex)])
+
+        dim = self.cell.get_spatial_dimension()
+        return {(0,) * dim: gem.ComponentTensor(product, multiindex)}


### PR DESCRIPTION
Similar to `QuadratureElement` in FFC, but this one returns symbolic identity matrices (GEM `Delta` nodes) rather than numerical ones, which makes it much easier to simplify away coefficient and maybe even argument evaluations.