### PR TITLE
Spectral elements return symbolic identity matrices

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, print_function, division
 
-from .fiat_elements import Lagrange, DiscontinuousLagrange, GaussLobattoLegendre, GaussLegendre  # noqa: F401
+from .fiat_elements import Lagrange, DiscontinuousLagrange  # noqa: F401
 from .fiat_elements import RaviartThomas, DiscontinuousRaviartThomas  # noqa: F401
 from .fiat_elements import BrezziDouglasMarini, BrezziDouglasFortinMarini  # noqa: F401
 from .fiat_elements import Nedelec, NedelecSecondKind, Regge  # noqa: F401
+from .spectral import GaussLobattoLegendre, GaussLegendre  # noqa: F401
 from .tensorfiniteelement import TensorFiniteElement  # noqa: F401
 from .tensor_product import TensorProductElement  # noqa: F401
 from .quadrilateral import QuadrilateralElement  # noqa: F401

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -262,19 +262,9 @@ class Lagrange(ScalarFiatElement):
         super(Lagrange, self).__init__(FIAT.Lagrange(cell, degree))
 
 
-class GaussLobattoLegendre(ScalarFiatElement):
-    def __init__(self, cell, degree):
-        super(GaussLobattoLegendre, self).__init__(FIAT.GaussLobattoLegendre(cell, degree))
-
-
 class DiscontinuousLagrange(ScalarFiatElement):
     def __init__(self, cell, degree):
         super(DiscontinuousLagrange, self).__init__(FIAT.DiscontinuousLagrange(cell, degree))
-
-
-class GaussLegendre(ScalarFiatElement):
-    def __init__(self, cell, degree):
-        super(GaussLegendre, self).__init__(FIAT.GaussLegendre(cell, degree))
 
 
 class VectorFiatElement(FiatElementBase):

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -64,6 +64,26 @@ class PointSet(AbstractPointSet):
             numpy.allclose(self.points, other.points, rtol=0, atol=tolerance)
 
 
+class GaussLegendrePointSet(PointSet):
+    """Gauss-Legendre quadrature points on the interval.
+
+    This facilitates implementing discontinuous spectral elements.
+    """
+    def __init__(self, points):
+        super(GaussLegendrePointSet, self).__init__(points)
+        assert self.points.shape[1] == 1
+
+
+class GaussLobattoLegendrePointSet(PointSet):
+    """Gauss-Lobatto-Legendre quadrature points on the interval.
+
+    This facilitates implementing continuous spectral elements.
+    """
+    def __init__(self, points):
+        super(GaussLobattoLegendrePointSet, self).__init__(points)
+        assert self.points.shape[1] == 1
+
+
 class TensorPointSet(AbstractPointSet):
 
     def __init__(self, factors):

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -48,7 +48,7 @@ def make_quadrature(ref_el, degree, scheme="default"):
         raise ValueError("Need positive degree, not %d" % degree)
 
     fiat_rule = fiat_scheme(ref_el, degree, scheme)
-    return QuadratureRule(fiat_rule.get_points(), fiat_rule.get_weights())
+    return QuadratureRule(PointSet(fiat_rule.get_points()), fiat_rule.get_weights())
 
 
 class AbstractQuadratureRule(with_metaclass(ABCMeta)):
@@ -68,16 +68,16 @@ class AbstractQuadratureRule(with_metaclass(ABCMeta)):
 class QuadratureRule(AbstractQuadratureRule):
     """Generic quadrature rule with no internal structure."""
 
-    def __init__(self, points, weights):
+    def __init__(self, point_set, weights):
         weights = numpy.asarray(weights)
-        assert len(points) == len(weights)
+        assert len(point_set.points) == len(weights)
 
-        self._points = numpy.asarray(points)
+        self.point_set = point_set
         self.weights = numpy.asarray(weights)
 
     @cached_property
     def point_set(self):
-        return PointSet(self._points)
+        pass  # set at initialisation
 
     @cached_property
     def weight_expression(self):

--- a/finat/spectral.py
+++ b/finat/spectral.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import, print_function, division
+
+import FIAT
+
+from finat.fiat_elements import ScalarFiatElement
+
+
+class GaussLobattoLegendre(ScalarFiatElement):
+    """1D continuous element with nodes at the Gauss-Lobatto points."""
+
+    def __init__(self, cell, degree):
+        fiat_element = FIAT.GaussLobattoLegendre(cell, degree)
+        super(GaussLobattoLegendre, self).__init__(fiat_element)
+
+
+class GaussLegendre(ScalarFiatElement):
+    """1D discontinuous element with nodes at the Gauss-Legendre points."""
+
+    def __init__(self, cell, degree):
+        fiat_element = FIAT.GaussLegendre(cell, degree)
+        super(GaussLegendre, self).__init__(fiat_element)

--- a/finat/spectral.py
+++ b/finat/spectral.py
@@ -2,7 +2,10 @@ from __future__ import absolute_import, print_function, division
 
 import FIAT
 
+import gem
+
 from finat.fiat_elements import ScalarFiatElement
+from finat.point_set import GaussLobattoLegendrePointSet, GaussLegendrePointSet
 
 
 class GaussLobattoLegendre(ScalarFiatElement):
@@ -12,6 +15,26 @@ class GaussLobattoLegendre(ScalarFiatElement):
         fiat_element = FIAT.GaussLobattoLegendre(cell, degree)
         super(GaussLobattoLegendre, self).__init__(fiat_element)
 
+    def basis_evaluation(self, order, ps, entity=None):
+        '''Return code for evaluating the element at known points on the
+        reference element.
+
+        :param order: return derivatives up to this order.
+        :param ps: the point set.
+        :param entity: the cell entity on which to tabulate.
+        '''
+        result = super(GaussLobattoLegendre, self).basis_evaluation(order, ps, entity)
+        cell_dimension = self.cell.get_dimension()
+        if entity is None or entity == (cell_dimension, 0):  # on cell interior
+            space_dim = self.space_dimension()
+            if isinstance(ps, GaussLobattoLegendrePointSet) and len(ps.points) == space_dim:
+                # Bingo: evaluation points match node locations!
+                spatial_dim = self.cell.get_spatial_dimension()
+                q, = ps.indices
+                r, = self.get_indices()
+                result[(0,) * spatial_dim] = gem.ComponentTensor(gem.Delta(q, r), (r,))
+        return result
+
 
 class GaussLegendre(ScalarFiatElement):
     """1D discontinuous element with nodes at the Gauss-Legendre points."""
@@ -19,3 +42,23 @@ class GaussLegendre(ScalarFiatElement):
     def __init__(self, cell, degree):
         fiat_element = FIAT.GaussLegendre(cell, degree)
         super(GaussLegendre, self).__init__(fiat_element)
+
+    def basis_evaluation(self, order, ps, entity=None):
+        '''Return code for evaluating the element at known points on the
+        reference element.
+
+        :param order: return derivatives up to this order.
+        :param ps: the point set.
+        :param entity: the cell entity on which to tabulate.
+        '''
+        result = super(GaussLegendre, self).basis_evaluation(order, ps, entity)
+        cell_dimension = self.cell.get_dimension()
+        if entity is None or entity == (cell_dimension, 0):  # on cell interior
+            space_dim = self.space_dimension()
+            if isinstance(ps, GaussLegendrePointSet) and len(ps.points) == space_dim:
+                # Bingo: evaluation points match node locations!
+                spatial_dim = self.cell.get_spatial_dimension()
+                q, = ps.indices
+                r, = self.get_indices()
+                result[(0,) * spatial_dim] = gem.ComponentTensor(gem.Delta(q, r), (r,))
+        return result


### PR DESCRIPTION
... for the zeroth derivative if tabulation points match the node locations.

Already works for Gauss-Legendre elements since default line quadrature from FIAT is Gauss-Legendre. Work for Gauss-Lobatto-Legendre as well if one manually provides the correct quadrature rule.