### PR TITLE
Mixed element and "transposable" tensor element

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -9,5 +9,6 @@ from .tensor_product import TensorProductElement  # noqa: F401
 from .quadrilateral import QuadrilateralElement  # noqa: F401
 from .enriched import EnrichedElement  # noqa: F401
 from .hdivcurl import HCurlElement, HDivElement  # noqa: F401
+from .mixed import MixedElement  # noqa: F401
 from .quadrature_element import QuadratureElement  # noqa: F401
 from . import quadrature  # noqa: F401

--- a/finat/mixed.py
+++ b/finat/mixed.py
@@ -1,0 +1,97 @@
+from __future__ import absolute_import, print_function, division
+from six import iteritems
+from six.moves import zip
+
+import numpy
+
+import gem
+
+from finat.finiteelementbase import FiniteElementBase
+from finat.enriched import EnrichedElement
+
+
+def MixedElement(elements):
+    """Constructor function for FEniCS-style mixed elements.
+
+    Implements mixed element using :py:class:`EnrichedElement` and
+    value shape transformations with :py:class:`MixedSubElement`.
+    """
+    sizes = [numpy.prod(element.value_shape, dtype=int)
+             for element in elements]
+    offsets = [int(offset) for offset in numpy.cumsum([0] + sizes)]
+    total_size = offsets.pop()
+    return EnrichedElement([MixedSubElement(element, total_size, offset)
+                            for offset, element in zip(offsets, elements)])
+
+
+class MixedSubElement(FiniteElementBase):
+    """Element wrapper that flattens value shape and places the flattened
+    vector in a longer vector of zeros."""
+
+    def __init__(self, element, size, offset):
+        assert 0 <= offset <= size
+        assert offset + numpy.prod(element.value_shape, dtype=int) <= size
+
+        super(MixedSubElement, self).__init__()
+        self.element = element
+        self.size = size
+        self.offset = offset
+
+    @property
+    def cell(self):
+        return self.element.cell
+
+    @property
+    def degree(self):
+        return self.element.degree
+
+    @property
+    def formdegree(self):
+        return self.element.formdegree
+
+    def entity_dofs(self):
+        return self.element.entity_dofs()
+
+    def entity_closure_dofs(self):
+        return self.element.entity_closure_dofs()
+
+    def space_dimension(self):
+        return self.element.space_dimension()
+
+    @property
+    def index_shape(self):
+        return self.element.index_shape
+
+    @property
+    def value_shape(self):
+        return (self.size,)
+
+    def _transform(self, v):
+        u = [gem.Zero()] * self.size
+        for j, zeta in enumerate(numpy.ndindex(self.element.value_shape)):
+            u[self.offset + j] = gem.Indexed(v, zeta)
+        return u
+
+    def _transform_evaluation(self, core_eval):
+        beta = self.get_indices()
+        zeta = self.get_value_indices()
+
+        def promote(table):
+            v = gem.partial_indexed(table, beta)
+            u = gem.ListTensor(self._transform(v))
+            return gem.ComponentTensor(gem.Indexed(u, zeta), beta + zeta)
+
+        return {alpha: promote(table)
+                for alpha, table in iteritems(core_eval)}
+
+    def basis_evaluation(self, order, ps, entity=None):
+        core_eval = self.element.basis_evaluation(order, ps, entity)
+        return self._transform_evaluation(core_eval)
+
+    def point_evaluation(self, order, refcoords, entity=None):
+        core_eval = self.element.point_evaluation(order, refcoords, entity)
+        return self._transform_evaluation(core_eval)
+
+    @property
+    def mapping(self):
+        return self.element.mapping

--- a/finat/tensorfiniteelement.py
+++ b/finat/tensorfiniteelement.py
@@ -29,8 +29,11 @@ class TensorFiniteElement(FiniteElementBase):
 
         :param element: The scalar finite element.
         :param shape: The geometric shape of the tensor element.
-        :param transpose: Tensor indices come before scalar basis
-                          function indices (boolean).
+        :param transpose: Changes the DoF ordering from the
+                          Firedrake-style XYZ XYZ XYZ XYZ to the
+                          FEniCS-style XXXX YYYY ZZZZ.  That is,
+                          tensor shape indices come before the scalar
+                          basis function indices when transpose=True.
 
         :math:`\boldsymbol\phi_{i\alpha\beta}` is, of course, tensor-valued. If
         we subscript the vector-value with :math:`\gamma\epsilon` then we can write:


### PR DESCRIPTION
Add a structured mixed element implemented through `EnrichedElement`, and make `TensorFiniteElement` "transposable": vector/tensor indices may come after or before the scalar basis function indices.