### PR TITLE
Add wrappers for more FIAT elements

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -1,9 +1,12 @@
 from __future__ import absolute_import, print_function, division
 
+from .fiat_elements import Bubble, CrouzeixRaviart, DiscontinuousTaylor  # noqa: F401
 from .fiat_elements import Lagrange, DiscontinuousLagrange  # noqa: F401
 from .fiat_elements import RaviartThomas, DiscontinuousRaviartThomas  # noqa: F401
 from .fiat_elements import BrezziDouglasMarini, BrezziDouglasFortinMarini  # noqa: F401
-from .fiat_elements import Nedelec, NedelecSecondKind, Regge  # noqa: F401
+from .fiat_elements import Nedelec, NedelecSecondKind  # noqa: F401
+from .fiat_elements import HellanHerrmannJohnson, Regge  # noqa: F401
+from .trace import HDivTrace  # noqa: F401
 from .spectral import GaussLobattoLegendre, GaussLegendre  # noqa: F401
 from .tensorfiniteelement import TensorFiniteElement  # noqa: F401
 from .tensor_product import TensorProductElement  # noqa: F401

--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -11,6 +11,7 @@ from .spectral import GaussLobattoLegendre, GaussLegendre  # noqa: F401
 from .tensorfiniteelement import TensorFiniteElement  # noqa: F401
 from .tensor_product import TensorProductElement  # noqa: F401
 from .quadrilateral import QuadrilateralElement  # noqa: F401
+from .discontinuous import DiscontinuousElement  # noqa: F401
 from .enriched import EnrichedElement  # noqa: F401
 from .hdivcurl import HCurlElement, HDivElement  # noqa: F401
 from .mixed import MixedElement  # noqa: F401

--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import, print_function, division
 
 from .fiat_elements import Bubble, CrouzeixRaviart, DiscontinuousTaylor  # noqa: F401
 from .fiat_elements import Lagrange, DiscontinuousLagrange  # noqa: F401
-from .fiat_elements import RaviartThomas, DiscontinuousRaviartThomas  # noqa: F401
 from .fiat_elements import BrezziDouglasMarini, BrezziDouglasFortinMarini  # noqa: F401
-from .fiat_elements import Nedelec, NedelecSecondKind  # noqa: F401
+from .fiat_elements import Nedelec, NedelecSecondKind, RaviartThomas  # noqa: F401
 from .fiat_elements import HellanHerrmannJohnson, Regge  # noqa: F401
 from .trace import HDivTrace  # noqa: F401
 from .spectral import GaussLobattoLegendre, GaussLegendre  # noqa: F401

--- a/finat/discontinuous.py
+++ b/finat/discontinuous.py
@@ -1,0 +1,59 @@
+from __future__ import absolute_import, print_function, division
+from six import iteritems
+
+from gem.utils import cached_property
+
+from finat.finiteelementbase import FiniteElementBase
+
+
+class DiscontinuousElement(FiniteElementBase):
+    """Element wrapper that makes a FInAT element discontinuous."""
+
+    def __init__(self, element):
+        super(DiscontinuousElement, self).__init__()
+        self.element = element
+
+    @property
+    def cell(self):
+        return self.element.cell
+
+    @property
+    def degree(self):
+        return self.element.degree
+
+    @cached_property
+    def formdegree(self):
+        # Always discontinuous!
+        return self.element.cell.get_spatial_dimension()
+
+    @cached_property
+    def _entity_dofs(self):
+        result = {dim: {i: [] for i in entities}
+                  for dim, entities in iteritems(self.cell.get_topology())}
+        cell_dimension = self.cell.get_dimension()
+        result[cell_dimension][0].extend(range(self.space_dimension()))
+        return result
+
+    def entity_dofs(self):
+        return self._entity_dofs
+
+    def space_dimension(self):
+        return self.element.space_dimension()
+
+    @property
+    def index_shape(self):
+        return self.element.index_shape
+
+    @property
+    def value_shape(self):
+        return self.element.value_shape
+
+    def basis_evaluation(self, order, ps, entity=None):
+        return self.element.basis_evaluation(order, ps, entity)
+
+    def point_evaluation(self, order, refcoords, entity=None):
+        return self.element.point_evaluation(order, refcoords, entity)
+
+    @property
+    def mapping(self):
+        return self.element.mapping

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -14,11 +14,11 @@ from finat.finiteelementbase import FiniteElementBase
 from finat.sympy2gem import sympy2gem
 
 
-class FiatElementBase(FiniteElementBase):
+class FiatElement(FiniteElementBase):
     """Base class for finite elements for which the tabulation is provided
     by FIAT."""
     def __init__(self, fiat_element):
-        super(FiatElementBase, self).__init__()
+        super(FiatElement, self).__init__()
         self._element = fiat_element
 
     @property
@@ -246,17 +246,17 @@ def point_evaluation_ciarlet(fiat_element, order, refcoords, entity):
     return result
 
 
-class Regge(FiatElementBase):  # naturally tensor valued
+class Regge(FiatElement):  # naturally tensor valued
     def __init__(self, cell, degree):
         super(Regge, self).__init__(FIAT.Regge(cell, degree))
 
 
-class HellanHerrmannJohnson(FiatElementBase):  # symmetric matrix valued
+class HellanHerrmannJohnson(FiatElement):  # symmetric matrix valued
     def __init__(self, cell, degree):
         super(HellanHerrmannJohnson, self).__init__(FIAT.HellanHerrmannJohnson(cell, degree))
 
 
-class ScalarFiatElement(FiatElementBase):
+class ScalarFiatElement(FiatElement):
     @property
     def value_shape(self):
         return ()
@@ -287,7 +287,7 @@ class DiscontinuousTaylor(ScalarFiatElement):
         super(DiscontinuousTaylor, self).__init__(FIAT.DiscontinuousTaylor(cell, degree))
 
 
-class VectorFiatElement(FiatElementBase):
+class VectorFiatElement(FiatElement):
     @property
     def value_shape(self):
         return (self.cell.get_spatial_dimension(),)

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -251,10 +251,25 @@ class Regge(FiatElementBase):  # naturally tensor valued
         super(Regge, self).__init__(FIAT.Regge(cell, degree))
 
 
+class HellanHerrmannJohnson(FiatElementBase):  # symmetric matrix valued
+    def __init__(self, cell, degree):
+        super(HellanHerrmannJohnson, self).__init__(FIAT.HellanHerrmannJohnson(cell, degree))
+
+
 class ScalarFiatElement(FiatElementBase):
     @property
     def value_shape(self):
         return ()
+
+
+class Bubble(ScalarFiatElement):
+    def __init__(self, cell, degree):
+        super(Bubble, self).__init__(FIAT.Bubble(cell, degree))
+
+
+class CrouzeixRaviart(ScalarFiatElement):
+    def __init__(self, cell, degree):
+        super(CrouzeixRaviart, self).__init__(FIAT.CrouzeixRaviart(cell, degree))
 
 
 class Lagrange(ScalarFiatElement):
@@ -265,6 +280,11 @@ class Lagrange(ScalarFiatElement):
 class DiscontinuousLagrange(ScalarFiatElement):
     def __init__(self, cell, degree):
         super(DiscontinuousLagrange, self).__init__(FIAT.DiscontinuousLagrange(cell, degree))
+
+
+class DiscontinuousTaylor(ScalarFiatElement):
+    def __init__(self, cell, degree):
+        super(DiscontinuousTaylor, self).__init__(FIAT.DiscontinuousTaylor(cell, degree))
 
 
 class VectorFiatElement(FiatElementBase):

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -298,11 +298,6 @@ class RaviartThomas(VectorFiatElement):
         super(RaviartThomas, self).__init__(FIAT.RaviartThomas(cell, degree))
 
 
-class DiscontinuousRaviartThomas(VectorFiatElement):
-    def __init__(self, cell, degree):
-        super(DiscontinuousRaviartThomas, self).__init__(FIAT.DiscontinuousRaviartThomas(cell, degree))
-
-
 class BrezziDouglasMarini(VectorFiatElement):
     def __init__(self, cell, degree):
         super(BrezziDouglasMarini, self).__init__(FIAT.BrezziDouglasMarini(cell, degree))

--- a/finat/trace.py
+++ b/finat/trace.py
@@ -1,0 +1,10 @@
+from __future__ import absolute_import, print_function, division
+
+import FIAT
+
+from finat.fiat_elements import ScalarFiatElement
+
+
+class HDivTrace(ScalarFiatElement):
+    def __init__(self, cell, degree):
+        super(HDivTrace, self).__init__(FIAT.HDivTrace(cell, degree))


### PR DESCRIPTION
Also adds a FInAT implementation of `ufl.BrokenElement`, similar to `FIAT.DiscontinuousElement`. So one can have, for example, a structured broken RTCF element.