### PR TITLE
Fix excessive memory consumption in entity_support_dofs

### DIFF
--- a/finat/quadrilateral.py
+++ b/finat/quadrilateral.py
@@ -32,15 +32,11 @@ class QuadrilateralElement(FiniteElementBase):
 
     @cached_property
     def _entity_dofs(self):
-        entity_dofs = self.product.entity_dofs()
-        flat_entity_dofs = {}
-        flat_entity_dofs[0] = entity_dofs[(0, 0)]
-        flat_entity_dofs[1] = dict(enumerate(
-            [v for k, v in sorted(iteritems(entity_dofs[(0, 1)]))] +
-            [v for k, v in sorted(iteritems(entity_dofs[(1, 0)]))]
-        ))
-        flat_entity_dofs[2] = entity_dofs[(1, 1)]
-        return flat_entity_dofs
+        return flatten(self.product.entity_dofs())
+
+    @cached_property
+    def _entity_support_dofs(self):
+        return flatten(self.product.entity_support_dofs())
 
     def entity_dofs(self):
         return self._entity_dofs
@@ -72,6 +68,17 @@ class QuadrilateralElement(FiniteElementBase):
     @property
     def mapping(self):
         return self.product.mapping
+
+
+def flatten(dofs):
+    flat_dofs = {}
+    flat_dofs[0] = dofs[(0, 0)]
+    flat_dofs[1] = dict(enumerate(
+        [v for k, v in sorted(iteritems(dofs[(0, 1)]))] +
+        [v for k, v in sorted(iteritems(dofs[(1, 0)]))]
+    ))
+    flat_dofs[2] = dofs[(1, 1)]
+    return flat_dofs
 
 
 def productise(entity):

--- a/finat/tensor_product.py
+++ b/finat/tensor_product.py
@@ -3,6 +3,7 @@ from six.moves import range, zip
 
 from functools import reduce
 from itertools import chain, product
+from operator import methodcaller
 
 import numpy
 
@@ -47,24 +48,11 @@ class TensorProductElement(FiniteElementBase):
 
     @cached_property
     def _entity_dofs(self):
-        shape = tuple(fe.space_dimension() for fe in self.factors)
-        entity_dofs = {}
-        for dim in product(*[fe.cell.get_topology().keys()
-                             for fe in self.factors]):
-            dim_dofs = []
-            topds = [fe.entity_dofs()[d]
-                     for fe, d in zip(self.factors, dim)]
-            for tuple_ei in product(*[sorted(topd) for topd in topds]):
-                tuple_vs = list(product(*[topd[ei]
-                                          for topd, ei in zip(topds, tuple_ei)]))
-                if tuple_vs:
-                    vs = list(numpy.ravel_multi_index(numpy.transpose(tuple_vs), shape))
-                    dim_dofs.append((tuple_ei, vs))
-                else:
-                    dim_dofs.append((tuple_ei, []))
-            # flatten entity numbers
-            entity_dofs[dim] = dict(enumerate(v for k, v in sorted(dim_dofs)))
-        return entity_dofs
+        return productise(self.factors, methodcaller("entity_dofs"))
+
+    @cached_property
+    def _entity_support_dofs(self):
+        return productise(self.factors, methodcaller("entity_support_dofs"))
 
     def entity_dofs(self):
         return self._entity_dofs
@@ -179,6 +167,31 @@ class TensorProductElement(FiniteElementBase):
             return mappings[0]
         else:
             return None
+
+
+def productise(factors, method):
+    '''Tensor product the dict mapping topological entities to dofs across factors.
+
+    :arg factors: element factors.
+    :arg method: instance method to call on each factor to get dofs.'''
+    shape = tuple(fe.space_dimension() for fe in factors)
+    dofs = {}
+    for dim in product(*[fe.cell.get_topology().keys()
+                         for fe in factors]):
+        dim_dofs = []
+        topds = [method(fe)[d]
+                 for fe, d in zip(factors, dim)]
+        for tuple_ei in product(*[sorted(topd) for topd in topds]):
+            tuple_vs = list(product(*[topd[ei]
+                                      for topd, ei in zip(topds, tuple_ei)]))
+            if tuple_vs:
+                vs = list(numpy.ravel_multi_index(numpy.transpose(tuple_vs), shape))
+                dim_dofs.append((tuple_ei, vs))
+            else:
+                dim_dofs.append((tuple_ei, []))
+        # flatten entity numbers
+        dofs[dim] = dict(enumerate(v for k, v in sorted(dim_dofs)))
+    return dofs
 
 
 def factor_point_set(product_cell, product_dim, point_set):


### PR DESCRIPTION
Previously, computation of entity_support_dofs did not exploit tensor
product structure, and so at high order, required allocation of
temporaries of size O(p^2d).  Fix this by computing the support dofs
on the element factors and productising them.