### PR TITLE
Fix excessive memory consumption in entity_support_dofs: Part 2

### DIFF
--- a/finat/hdivcurl.py
+++ b/finat/hdivcurl.py
@@ -38,6 +38,9 @@ class WrapperElementBase(FiniteElementBase):
     def entity_closure_dofs(self):
         return self.wrappee.entity_closure_dofs()
 
+    def entity_support_dofs(self):
+        return self.wrappee.entity_support_dofs()
+
     def space_dimension(self):
         return self.wrappee.space_dimension()
 

--- a/finat/mixed.py
+++ b/finat/mixed.py
@@ -55,6 +55,9 @@ class MixedSubElement(FiniteElementBase):
     def entity_closure_dofs(self):
         return self.element.entity_closure_dofs()
 
+    def entity_support_dofs(self):
+        return self.element.entity_support_dofs()
+
     def space_dimension(self):
         return self.element.space_dimension()
 


### PR DESCRIPTION
I need this for more elements in order to run high-order H(div) and H(curl) elements.