### PR TITLE
Remove overenthusiastic checks

### DIFF
--- a/finat/spectral.py
+++ b/finat/spectral.py
@@ -21,7 +21,7 @@ class GaussLobattoLegendre(ScalarFiatElement):
         :param ps: the point set.
         :param entity: the cell entity on which to tabulate.
         '''
-        assert coordinate_mapping is None
+
         result = super(GaussLobattoLegendre, self).basis_evaluation(order, ps, entity)
         cell_dimension = self.cell.get_dimension()
         if entity is None or entity == (cell_dimension, 0):  # on cell interior
@@ -50,6 +50,7 @@ class GaussLegendre(ScalarFiatElement):
         :param ps: the point set.
         :param entity: the cell entity on which to tabulate.
         '''
+
         assert coordinate_mapping is None
         result = super(GaussLegendre, self).basis_evaluation(order, ps, entity)
         cell_dimension = self.cell.get_dimension()

--- a/finat/spectral.py
+++ b/finat/spectral.py
@@ -51,7 +51,6 @@ class GaussLegendre(ScalarFiatElement):
         :param entity: the cell entity on which to tabulate.
         '''
 
-        assert coordinate_mapping is None
         result = super(GaussLegendre, self).basis_evaluation(order, ps, entity)
         cell_dimension = self.cell.get_dimension()
         if entity is None or entity == (cell_dimension, 0):  # on cell interior


### PR DESCRIPTION
There are a couple of coordinate mapping checks on spectral elements which do not appear for equispaced elements and which don't seem to have a purpose, but which break things.