### PR TITLE
Mimetic Spectral Elements

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -5,12 +5,13 @@ from .fiat_elements import BrezziDouglasMarini, BrezziDouglasFortinMarini  # noq
 from .fiat_elements import Nedelec, NedelecSecondKind, RaviartThomas  # noqa: F401
 from .fiat_elements import HellanHerrmannJohnson, Regge  # noqa: F401
 from .fiat_elements import FacetBubble  # noqa: F401
+from .fiat_elements import EdgeExtendedGaussLegendre, EdgeGaussLobattoLegendre  # noqa: F401
 from .argyris import Argyris            # noqa: F401
 from .bell import Bell                  # noqa: F401
 from .hermite import Hermite            # noqa: F401
 from .morley import Morley              # noqa: F401
 from .trace import HDivTrace  # noqa: F401
-from .spectral import GaussLobattoLegendre, GaussLegendre  # noqa: F401
+from .spectral import GaussLobattoLegendre, GaussLegendre, ExtendedGaussLegendre  # noqa: F401
 from .tensorfiniteelement import TensorFiniteElement  # noqa: F401
 from .tensor_product import TensorProductElement  # noqa: F401
 from .cube import FlattenedDimensions  # noqa: F401

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -328,6 +328,16 @@ class BrezziDouglasFortinMarini(VectorFiatElement):
         super(BrezziDouglasFortinMarini, self).__init__(FIAT.BrezziDouglasFortinMarini(cell, degree))
 
 
+class EdgeGaussLobattoLegendre(ScalarFiatElement):
+    def __init__(self, cell, degree):
+        super(EdgeGaussLobattoLegendre, self).__init__(FIAT.EdgeGaussLobattoLegendre(cell, degree))
+
+
+class EdgeExtendedGaussLegendre(ScalarFiatElement):
+    def __init__(self, cell, degree):
+        super(EdgeExtendedGaussLegendre, self).__init__(FIAT.EdgeExtendedGaussLegendre(cell, degree))
+
+
 class Nedelec(VectorFiatElement):
     def __init__(self, cell, degree):
         super(Nedelec, self).__init__(FIAT.Nedelec(cell, degree))

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -91,6 +91,16 @@ class GaussLegendrePointSet(PointSet):
         assert self.points.shape[1] == 1
 
 
+class ExtendedGaussLegendrePointSet(PointSet):
+    """Extended-Gauss-Legendre quadrature points on the interval.
+
+    This facilitates implementing dual mimetic continuous spectral elements.
+    """
+    def __init__(self, points):
+        super(ExtendedGaussLegendrePointSet, self).__init__(points)
+        assert self.points.shape[1] == 1
+
+
 class GaussLobattoLegendrePointSet(PointSet):
     """Gauss-Lobatto-Legendre quadrature points on the interval.
 

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,2 +1,2 @@
-git+https://github.com/firedrakeproject/fiat.git#egg=fiat
-git+https://github.com/firedrakeproject/tsfc.git#tsfc=fiat
+git+https://github.com/firedrakeproject/fiat.git@mse#egg=fiat
+git+https://github.com/firedrakeproject/tsfc.git@mse#tsfc=fiat


### PR DESCRIPTION
This pull request adds mimetic spectral elements (described at https://www.sciencedirect.com/science/article/pii/S0021999113006414 and https://arxiv.org/abs/1111.4304), both the primal and dual complexes. This is done by adding the relevant 1D H1 element for the dual complex: Extended Gauss Legendre (EGL); and the L2 edge elements associated with GLL and EGL. These are non-Ciarlet finite elements that use a basis that histopolates (http://people.math.sfu.ca/~nrobidou/public_html/prints/histogram/histogram.pdf) rather than interpolates. The nD deRham complex on hypercubes is then accessible using the variant keyword (either “mse” or “dualmse”) with the relevant elements (DQ, Q, RTCF, etc.).

It requires https://github.com/FEniCS/ufl/pull/5 and https://github.com/FEniCS/fiat/pull/29.

It also requires correct (integral-preserving) L2 pullbacks, which are implemented at https://github.com/FEniCS/ufl/pull/4.