### PR TITLE
enriched: Return subelement for single argument

### DIFF
--- a/finat/enriched.py
+++ b/finat/enriched.py
@@ -13,9 +13,13 @@ class EnrichedElement(FiniteElementBase):
     """A finite element whose basis functions are the union of the
     basis functions of several other finite elements."""
 
-    def __init__(self, elements):
-        super(EnrichedElement, self).__init__()
-        self.elements = tuple(elements)
+    def __new__(cls, elements):
+        if len(elements) == 1:
+            return elements[0]
+        else:
+            self = super().__new__(cls)
+            self.elements = tuple(elements)
+            return self
 
     @cached_property
     def cell(self):


### PR DESCRIPTION
Catches a case where someone built an enriched element with only a
single subelement, which subsequently dies in tree_map(max, ...)
because that implicitly relies on there being at least two
arguments (such that mapping max works).

Fixes firedrakeproject/firedrake#1762.