### PR TITLE
Fix age-old typo

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,2 +1,2 @@
 git+https://github.com/firedrakeproject/fiat.git#egg=fiat
-git+https://github.com/firedrakeproject/tsfc.git#tsfc=fiat
+git+https://github.com/firedrakeproject/tsfc.git#egg=tsfc


### PR DESCRIPTION
This typo makes me wonder if these `#egg=` specifications are required or useful at all.