### PR TITLE
Interpolation onto a Vertex Only Mesh (Old)

### DIFF
--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -9,7 +9,7 @@ from gem.interpreter import evaluate
 from gem.utils import cached_property
 
 from finat.quadrature import make_quadrature
-from finat.point_set import PointSet
+from finat.point_set import PointSet, UnknownPointSingleton
 
 
 class FiniteElementBase(metaclass=ABCMeta):
@@ -246,6 +246,11 @@ class FiniteElementBase(metaclass=ABCMeta):
             for j in range(len(dual_functional)):
                 # Ignore alpha, just extract point (x_j) and weights (q_j)
                 x_j, q_j, _ = dual_functional[j]
+
+                # Don't try to make a matrix for a runtime point
+                if isinstance(x_j, UnknownPointSingleton):
+                    can_construct = False
+                    break
 
                 # Esure all weights have the same shape
                 if last_shape is not None:

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -53,13 +53,13 @@ class PointSingleton(AbstractPointSet):
         assert len(point.shape) == 1
         self.point = point
 
-    @property
+    @cached_property
     def points(self):
         # Make sure we conform to the expected (# of points, point dimension)
         # shape
         return self.point.reshape(1, -1)
 
-    @property
+    @cached_property
     def indices(self):
         return ()
 

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -69,12 +69,28 @@ class PointSingleton(AbstractPointSet):
 
 
 class UnknownPointSingleton(AbstractPointSet):
-    """A single unknown point."""
+    """A point set representing a single point with unknown location but known
+    `gem.Variable` expression.
+
+    Stored points are `numpy.nan`s to indicate that they are not known.
+
+    In the future this can be easily replaced with an equivalent for a whole
+    point set representing multiple points though storing the full array of
+    `numpy.nans` may become undesirable and require interface changes."""
 
     def __init__(self, point_expr):
+        """Build a PointSingleton from a gem expression for a single point.
+
+        :arg point_expr: A `gem.Variable` expression representing a single
+            point of shape (D,) where D is the dimension of the point.
+            Since this represents a single point and is a `gem.Variable` it
+            should have no free indices."""
         assert isinstance(point_expr, gem.Variable)
+        # Check we only have 1 point
+        assert point_expr.free_indices == ()
+        assert len(point_expr.shape) == 1
         self.expression = point_expr
-        self.points = numpy.full((1, 1), numpy.nan)
+        self.points = numpy.full(point_expr.shape, numpy.nan).reshape(1, -1)
 
     @cached_property
     def points(self):

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -68,6 +68,27 @@ class PointSingleton(AbstractPointSet):
         return gem.Literal(self.point)
 
 
+class UnknownPointSingleton(AbstractPointSet):
+    """A single unknown point."""
+
+    def __init__(self, point_expr):
+        assert isinstance(point_expr, gem.Variable)
+        self.expression = point_expr
+        self.points = numpy.full((1, 1), numpy.nan)
+
+    @cached_property
+    def points(self):
+        pass  # set at initialisation
+
+    @cached_property
+    def indices(self):
+        return self.expression.free_indices
+
+    @cached_property
+    def expression(self):
+        pass  # set at initialisation
+
+
 class PointSet(AbstractPointSet):
     """A basic point set with no internal structure representing a vector of
     points."""

--- a/finat/quadrature_element.py
+++ b/finat/quadrature_element.py
@@ -10,7 +10,7 @@ from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
 from finat.quadrature import make_quadrature, AbstractQuadratureRule
-from finat.point_set import PointSingleton
+from finat.point_set import PointSingleton, UnknownPointSingleton
 
 
 class QuadratureElement(FiniteElementBase):
@@ -104,18 +104,24 @@ class QuadratureElement(FiniteElementBase):
     def dual_basis(self):
         # Point evaluations at each quadrature point with no derivatives
         duals = []
-        for pt in self._rule.point_set.points:
-            point_set = PointSingleton(pt)
+        if isinstance(self._rule.point_set, UnknownPointSingleton):
+            point_set = self._rule.point_set
             weight_tensor = gem.Literal(1)
             alpha_tensor = gem.Literal(1)
-            # shorthand
             duals.append(tuple([tuple([[(point_set, weight_tensor, alpha_tensor), ], ]), None]))
-            # below is equivalent to shorthand - see fiat_elements.FiatElement.dual_basis
-            # pts_in_derivs = []
-            # pts_in_derivs.append((point_set, weight_tensor, alpha_tensor))
-            # derivs = []
-            # derivs.append(pts_in_derivs)
-            # duals.append(tuple([tuple(derivs), None]))
+        else:
+            for pt in self._rule.point_set.points:
+                point_set = PointSingleton(pt)
+                weight_tensor = gem.Literal(1)
+                alpha_tensor = gem.Literal(1)
+                # shorthand
+                duals.append(tuple([tuple([[(point_set, weight_tensor, alpha_tensor), ], ]), None]))
+                # below is equivalent to shorthand - see fiat_elements.FiatElement.dual_basis
+                # pts_in_derivs = []
+                # pts_in_derivs.append((point_set, weight_tensor, alpha_tensor))
+                # derivs = []
+                # derivs.append(pts_in_derivs)
+                # duals.append(tuple([tuple(derivs), None]))
         return tuple(duals)
 
     @property

--- a/finat/quadrature_element.py
+++ b/finat/quadrature_element.py
@@ -9,16 +9,21 @@ from gem.interpreter import evaluate
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
-from finat.quadrature import make_quadrature
+from finat.quadrature import make_quadrature, AbstractQuadratureRule
 from finat.point_set import PointSingleton
 
 
 class QuadratureElement(FiniteElementBase):
     """A set of quadrature points pretending to be a finite element."""
 
-    def __init__(self, cell, degree, scheme="default"):
+    def __init__(self, cell, degree, scheme="default", rule=None):
         self.cell = cell
-        self._rule = make_quadrature(cell, degree, scheme)
+        if rule is not None:
+            if not isinstance(rule, AbstractQuadratureRule):
+                raise TypeError("rule is not an AbstractQuadratureRule")
+            self._rule = rule
+        else:
+            self._rule = make_quadrature(cell, degree, scheme)
 
     @cached_property
     def cell(self):


### PR DESCRIPTION
Draft for changes needed to interpolate onto a Vertex Only Mesh from a suitable parent mesh.

Based on top of branch `dual_base_fiat` - see draft PR #57 . Base should change to master when that PR is complete (or if this diverges and stops being dependent on #57).

Linked PRs: https://github.com/firedrakeproject/firedrake/pull/1815 & https://github.com/firedrakeproject/tsfc/pull/226