### PR TITLE
Add ability to construct the equivalent FIAT element

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -19,6 +19,7 @@ from .discontinuous import DiscontinuousElement  # noqa: F401
 from .enriched import EnrichedElement  # noqa: F401
 from .hdivcurl import HCurlElement, HDivElement  # noqa: F401
 from .mixed import MixedElement  # noqa: F401
+from .nodal_enriched import NodalEnrichedElement  # noqa: 401
 from .quadrature_element import QuadratureElement  # noqa: F401
 from .restricted import RestrictedElement          # noqa: F401
 from .runtime_tabulated import RuntimeTabulated  # noqa: F401

--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -1,3 +1,4 @@
+from .fiat_elements import Bernstein  # noqa: F401
 from .fiat_elements import Bubble, CrouzeixRaviart, DiscontinuousTaylor  # noqa: F401
 from .fiat_elements import Lagrange, DiscontinuousLagrange  # noqa: F401
 from .fiat_elements import DPC, Serendipity  # noqa: F401

--- a/finat/cube.py
+++ b/finat/cube.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function, division
 
 from FIAT.reference_element import UFCHexahedron, UFCQuadrilateral
 from FIAT.reference_element import compute_unflattening_map, flatten_entities
+from FIAT.tensor_product import FlattenedDimensions as FIAT_FlattenedDimensions
 
 from gem.utils import cached_property
 
@@ -53,10 +54,7 @@ class FlattenedDimensions(FiniteElementBase):
 
     @cached_property
     def fiat_equivalent(self):
-        # On-demand loading of FIAT module
-        from FIAT.tensor_product import FlattenedDimensions
-
-        return FlattenedDimensions(self.product.fiat_equivalent)
+        return FIAT_FlattenedDimensions(self.product.fiat_equivalent)
 
     def basis_evaluation(self, order, ps, entity=None, coordinate_mapping=None):
         """Return code for evaluating the element at known points on the

--- a/finat/cube.py
+++ b/finat/cube.py
@@ -51,6 +51,13 @@ class FlattenedDimensions(FiniteElementBase):
     def space_dimension(self):
         return self.product.space_dimension()
 
+    @cached_property
+    def fiat_equivalent(self):
+        # On-demand loading of FIAT module
+        from FIAT.tensor_product import FlattenedDimensions
+
+        return FlattenedDimensions(self.product.fiat_equivalent)
+
     def basis_evaluation(self, order, ps, entity=None, coordinate_mapping=None):
         """Return code for evaluating the element at known points on the
         reference element.

--- a/finat/discontinuous.py
+++ b/finat/discontinuous.py
@@ -45,6 +45,20 @@ class DiscontinuousElement(FiniteElementBase):
     def value_shape(self):
         return self.element.value_shape
 
+    @cached_property
+    def fiat_equivalent(self):
+        from FIAT.discontinuous import DiscontinuousElement
+        from FIAT.discontinuous_raviart_thomas import DiscontinuousRaviartThomas
+        from FIAT.raviart_thomas import RaviartThomas
+
+        fiat_element = self.element.fiat_equivalent
+        if isinstance(fiat_element, RaviartThomas):
+            ref_el = fiat_element.get_reference_element()
+            deg = fiat_element.degree()
+            return DiscontinuousRaviartThomas(ref_el, deg)
+        else:
+            return DiscontinuousElement(fiat_element)
+
     def basis_evaluation(self, order, ps, entity=None, coordinate_mapping=None):
         return self.element.basis_evaluation(order, ps, entity, coordinate_mapping=coordinate_mapping)
 

--- a/finat/discontinuous.py
+++ b/finat/discontinuous.py
@@ -1,3 +1,5 @@
+import FIAT
+
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
@@ -47,17 +49,7 @@ class DiscontinuousElement(FiniteElementBase):
 
     @cached_property
     def fiat_equivalent(self):
-        from FIAT.discontinuous import DiscontinuousElement
-        from FIAT.discontinuous_raviart_thomas import DiscontinuousRaviartThomas
-        from FIAT.raviart_thomas import RaviartThomas
-
-        fiat_element = self.element.fiat_equivalent
-        if isinstance(fiat_element, RaviartThomas):
-            ref_el = fiat_element.get_reference_element()
-            deg = fiat_element.degree()
-            return DiscontinuousRaviartThomas(ref_el, deg)
-        else:
-            return DiscontinuousElement(fiat_element)
+        return FIAT.DiscontinuousElement(self.element.fiat_equivalent)
 
     def basis_evaluation(self, order, ps, entity=None, coordinate_mapping=None):
         return self.element.basis_evaluation(order, ps, entity, coordinate_mapping=coordinate_mapping)

--- a/finat/enriched.py
+++ b/finat/enriched.py
@@ -3,6 +3,8 @@ from operator import add, methodcaller
 
 import numpy
 
+import FIAT
+
 import gem
 from gem.utils import cached_property
 
@@ -71,12 +73,11 @@ class EnrichedElement(FiniteElementBase):
 
         if all(isinstance(e, MixedSubElement) for e in self.elements):
             # EnrichedElement is actually a MixedElement
-            from FIAT.mixed import MixedElement  # on-demand loading
-            return MixedElement([e.element.fiat_equivalent
-                                 for e in self.elements], ref_el=self.cell)
+            return FIAT.MixedElement([e.element.fiat_equivalent
+                                      for e in self.elements], ref_el=self.cell)
         else:
-            from FIAT.enriched import EnrichedElement  # on-demand loading
-            return EnrichedElement(*[e.fiat_equivalent for e in self.elements])
+            return FIAT.EnrichedElement(*[e.fiat_equivalent
+                                          for e in self.elements])
 
     def _compose_evaluations(self, results):
         keys, = set(map(frozenset, results))

--- a/finat/enriched.py
+++ b/finat/enriched.py
@@ -76,8 +76,8 @@ class EnrichedElement(FiniteElementBase):
             return FIAT.MixedElement([e.element.fiat_equivalent
                                       for e in self.elements], ref_el=self.cell)
         else:
-            return FIAT.EnrichedElement(*[e.fiat_equivalent
-                                          for e in self.elements])
+            return FIAT.EnrichedElement(*(e.fiat_equivalent
+                                          for e in self.elements))
 
     def _compose_evaluations(self, results):
         keys, = set(map(frozenset, results))

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -48,6 +48,11 @@ class FiatElement(FiniteElementBase):
     def value_shape(self):
         return self._element.value_shape()
 
+    @property
+    def fiat_equivalent(self):
+        # Just return the underlying FIAT element
+        return self._element
+
     def basis_evaluation(self, order, ps, entity=None, coordinate_mapping=None):
         '''Return code for evaluating the element at known points on the
         reference element.

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -275,7 +275,7 @@ class ScalarFiatElement(FiatElement):
 class Bernstein(ScalarFiatElement):
     # TODO: Replace this with a smarter implementation
     def __init__(self, cell, degree):
-        super(Bernstein, self).__init__(FIAT.Bernstein(cell, degree))
+        super().__init__(FIAT.Bernstein(cell, degree))
 
 
 class Bubble(ScalarFiatElement):

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -272,6 +272,12 @@ class ScalarFiatElement(FiatElement):
         return ()
 
 
+class Bernstein(ScalarFiatElement):
+    # TODO: Replace this with a smarter implementation
+    def __init__(self, cell, degree):
+        super(Bernstein, self).__init__(FIAT.Bernstein(cell, degree))
+
+
 class Bubble(ScalarFiatElement):
     def __init__(self, cell, degree):
         super(Bubble, self).__init__(FIAT.Bubble(cell, degree))

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -102,10 +102,9 @@ class FiniteElementBase(metaclass=ABCMeta):
     @property
     def fiat_equivalent(self):
         '''The FIAT element equivalent to this FInAT element.'''
-        raise NotImplementedError(str.format(
-            "Cannot make equivalent FIAT element for {classname}",
-            classname=type(self).__name__
-        ))
+        raise NotImplementedError(
+            f"Cannot make equivalent FIAT element for {type(self).__name__}"
+        )
 
     def get_indices(self):
         '''A tuple of GEM :class:`Index` of the correct extents to loop over

--- a/finat/finiteelementbase.py
+++ b/finat/finiteelementbase.py
@@ -99,6 +99,14 @@ class FiniteElementBase(metaclass=ABCMeta):
     def value_shape(self):
         '''A tuple indicating the shape of the element.'''
 
+    @property
+    def fiat_equivalent(self):
+        '''The FIAT element equivalent to this FInAT element.'''
+        raise NotImplementedError(str.format(
+            "Cannot make equivalent FIAT element for {classname}",
+            classname=type(self).__name__
+        ))
+
     def get_indices(self):
         '''A tuple of GEM :class:`Index` of the correct extents to loop over
         the basis functions of this element.'''

--- a/finat/hdivcurl.py
+++ b/finat/hdivcurl.py
@@ -1,3 +1,4 @@
+from FIAT.hdivcurl import Hdiv, Hcurl
 from FIAT.reference_element import LINE
 
 import gem
@@ -91,7 +92,6 @@ class HDivElement(WrapperElementBase):
 
     @cached_property
     def fiat_equivalent(self):
-        from FIAT.hdivcurl import Hdiv  # on-demand loading
         return Hdiv(self.wrappee.fiat_equivalent)
 
     @property
@@ -120,7 +120,6 @@ class HCurlElement(WrapperElementBase):
 
     @cached_property
     def fiat_equivalent(self):
-        from FIAT.hdivcurl import Hcurl  # on-demand loading
         return Hcurl(self.wrappee.fiat_equivalent)
 
     @property

--- a/finat/hdivcurl.py
+++ b/finat/hdivcurl.py
@@ -1,6 +1,7 @@
 from FIAT.reference_element import LINE
 
 import gem
+from gem.utils import cached_property
 from finat.finiteelementbase import FiniteElementBase
 from finat.tensor_product import TensorProductElement
 
@@ -88,6 +89,11 @@ class HDivElement(WrapperElementBase):
     def formdegree(self):
         return self.cell.get_spatial_dimension() - 1
 
+    @cached_property
+    def fiat_equivalent(self):
+        from FIAT.hdivcurl import Hdiv  # on-demand loading
+        return Hdiv(self.wrappee.fiat_equivalent)
+
     @property
     def mapping(self):
         return "contravariant piola"
@@ -111,6 +117,11 @@ class HCurlElement(WrapperElementBase):
     @property
     def formdegree(self):
         return 1
+
+    @cached_property
+    def fiat_equivalent(self):
+        from FIAT.hdivcurl import Hcurl  # on-demand loading
+        return Hcurl(self.wrappee.fiat_equivalent)
 
     @property
     def mapping(self):

--- a/finat/nodal_enriched.py
+++ b/finat/nodal_enriched.py
@@ -1,0 +1,12 @@
+import FIAT
+
+from finat.fiat_elements import FiatElement
+
+
+class NodalEnrichedElement(FiatElement):
+    """An enriched element with a nodal basis."""
+
+    def __init__(self, elements):
+        fiat_elements = [elem.fiat_equivalent for elem in elements]
+        nodal_enriched = FIAT.NodalEnrichedElement(*fiat_elements)
+        super(NodalEnrichedElement, self).__init__(nodal_enriched)

--- a/finat/nodal_enriched.py
+++ b/finat/nodal_enriched.py
@@ -7,6 +7,6 @@ class NodalEnrichedElement(FiatElement):
     """An enriched element with a nodal basis."""
 
     def __init__(self, elements):
-        fiat_elements = [elem.fiat_equivalent for elem in elements]
-        nodal_enriched = FIAT.NodalEnrichedElement(*fiat_elements)
-        super(NodalEnrichedElement, self).__init__(nodal_enriched)
+        nodal_enriched = FIAT.NodalEnrichedElement(*(elem.fiat_equivalent
+                                                     for elem in elements))
+        super().__init__(nodal_enriched)

--- a/finat/quadrature_element.py
+++ b/finat/quadrature_element.py
@@ -2,6 +2,8 @@ from functools import reduce
 
 import numpy
 
+import FIAT
+
 import gem
 from gem.utils import cached_property
 
@@ -53,12 +55,9 @@ class QuadratureElement(FiniteElementBase):
 
     @cached_property
     def fiat_equivalent(self):
-        # On-demand loading of FIAT module
-        from FIAT.quadrature_element import QuadratureElement
-
         ps = self._rule.point_set
         weights = getattr(self._rule, 'weights', None)
-        return QuadratureElement(self.cell, ps.points, weights)
+        return FIAT.QuadratureElement(self.cell, ps.points, weights)
 
     def basis_evaluation(self, order, ps, entity=None, coordinate_mapping=None):
         '''Return code for evaluating the element at known points on the

--- a/finat/quadrature_element.py
+++ b/finat/quadrature_element.py
@@ -51,6 +51,15 @@ class QuadratureElement(FiniteElementBase):
     def value_shape(self):
         return ()
 
+    @cached_property
+    def fiat_equivalent(self):
+        # On-demand loading of FIAT module
+        from FIAT.quadrature_element import QuadratureElement
+
+        ps = self._rule.point_set
+        weights = getattr(self._rule, 'weights', None)
+        return QuadratureElement(self.cell, ps.points, weights)
+
     def basis_evaluation(self, order, ps, entity=None, coordinate_mapping=None):
         '''Return code for evaluating the element at known points on the
         reference element.

--- a/finat/tensor_product.py
+++ b/finat/tensor_product.py
@@ -4,6 +4,7 @@ from operator import methodcaller
 
 import numpy
 
+import FIAT
 from FIAT.polynomial_set import mis
 from FIAT.reference_element import TensorProductCell
 
@@ -67,12 +68,9 @@ class TensorProductElement(FiniteElementBase):
 
     @cached_property
     def fiat_equivalent(self):
-        # On-demand loading of FIAT module
-        from FIAT.tensor_product import TensorProductElement
-
         # FIAT TensorProductElement support only 2 factors
         A, B = self.factors
-        return TensorProductElement(A.fiat_equivalent, B.fiat_equivalent)
+        return FIAT.TensorProductElement(A.fiat_equivalent, B.fiat_equivalent)
 
     def _factor_entity(self, entity):
         # Default entity

--- a/finat/tensor_product.py
+++ b/finat/tensor_product.py
@@ -65,6 +65,15 @@ class TensorProductElement(FiniteElementBase):
     def value_shape(self):
         return self._value_shape
 
+    @cached_property
+    def fiat_equivalent(self):
+        # On-demand loading of FIAT module
+        from FIAT.tensor_product import TensorProductElement
+
+        # FIAT TensorProductElement support only 2 factors
+        A, B = self.factors
+        return TensorProductElement(A.fiat_equivalent, B.fiat_equivalent)
+
     def _factor_entity(self, entity):
         # Default entity
         if entity is None:


### PR DESCRIPTION
- Adds `.fiat_equivalent` property that gives the equivalent FIAT element for any particular FInAT element.
- Mostly implemented as `cached_property`, so as to simulate the caching feature of the FIAT interface in TSFC.