### PR TITLE
Fix tabulation for zany elements

### DIFF
--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -101,8 +101,9 @@ class FiatElement(FiniteElementBase):
                     assert np.allclose(table, 0.0)
                     exprs.append(gem.Zero(self.index_shape))
             if self.value_shape:
-                # As above, this extent may be different from that advertised by the finat element.
-                beta = self.get_indices()
+                # As above, this extent may be different from that
+                # advertised by the finat element.
+                beta = tuple(gem.Index(extent=i) for i in index_shape)
                 assert len(beta) == len(self.get_indices())
 
                 zeta = self.get_value_indices()


### PR DESCRIPTION
We do need to obey index_shape, but we need to generate indices whose
extents match index_shape.