### PR TITLE
Add KMV elements

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -5,6 +5,7 @@ from .fiat_elements import BrezziDouglasMarini, BrezziDouglasFortinMarini  # noq
 from .fiat_elements import Nedelec, NedelecSecondKind, RaviartThomas  # noqa: F401
 from .fiat_elements import HellanHerrmannJohnson, Regge  # noqa: F401
 from .fiat_elements import FacetBubble  # noqa: F401
+from .fiat_elements import KongMulderVeldhuizen  # noqa: F401
 from .argyris import Argyris            # noqa: F401
 from .bell import Bell                  # noqa: F401
 from .hermite import Hermite            # noqa: F401

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -287,6 +287,11 @@ class Lagrange(ScalarFiatElement):
         super(Lagrange, self).__init__(FIAT.Lagrange(cell, degree))
 
 
+class KongMulderVeldhuizen(ScalarFiatElement):
+    def __init__(self, cell, degree):
+        super(KongMulderVeldhuizen, self).__init__(FIAT.KongMulderVeldhuizen(cell, degree))
+
+
 class DiscontinuousLagrange(ScalarFiatElement):
     def __init__(self, cell, degree):
         super(DiscontinuousLagrange, self).__init__(FIAT.DiscontinuousLagrange(cell, degree))

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -10,6 +10,37 @@ import gem
 from finat.finiteelementbase import FiniteElementBase
 from finat.sympy2gem import sympy2gem
 
+try:
+    from firedrake_citations import Citations
+    Citations().add("Geevers2018new", """
+@article{Geevers2018new,
+ title={New higher-order mass-lumped tetrahedral elements for wave propagation modelling},
+ author={Geevers, Sjoerd and Mulder, Wim A and van der Vegt, Jaap JW},
+ journal={SIAM journal on scientific computing},
+ volume={40},
+ number={5},
+ pages={A2830--A2857},
+ year={2018},
+ publisher={SIAM},
+ doi={https://doi.org/10.1137/18M1175549},
+}
+""")
+    Citations().add("Chin1999higher", """
+@article{chin1999higher,
+ title={Higher-order triangular and tetrahedral finite elements with mass lumping for solving the wave equation},
+ author={Chin-Joe-Kong, MJS and Mulder, Wim A and Van Veldhuizen, M},
+ journal={Journal of Engineering Mathematics},
+ volume={35},
+ number={4},
+ pages={405--426},
+ year={1999},
+ publisher={Springer},
+ doi={https://doi.org/10.1023/A:1004420829610},
+}
+""")
+except ImportError:
+    Citations = None
+
 
 class FiatElement(FiniteElementBase):
     """Base class for finite elements for which the tabulation is provided
@@ -290,6 +321,9 @@ class Lagrange(ScalarFiatElement):
 class KongMulderVeldhuizen(ScalarFiatElement):
     def __init__(self, cell, degree):
         super(KongMulderVeldhuizen, self).__init__(FIAT.KongMulderVeldhuizen(cell, degree))
+        if Citations is not None:
+            Citations().register("Chin1999higher")
+            Citations().register("Geevers2018new")
 
 
 class DiscontinuousLagrange(ScalarFiatElement):


### PR DESCRIPTION
Kong-Mulder-Veldhuizen elements are higher-order, mass-lumpable simplicial elements.  This PR wraps up the associated elements in FIAT.