### PR TITLE
Always give weights to a QuadratureElement.

### DIFF
--- a/finat/quadrature_element.py
+++ b/finat/quadrature_element.py
@@ -5,6 +5,7 @@ import numpy
 import FIAT
 
 import gem
+from gem.interpreter import evaluate
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
@@ -57,6 +58,12 @@ class QuadratureElement(FiniteElementBase):
     def fiat_equivalent(self):
         ps = self._rule.point_set
         weights = getattr(self._rule, 'weights', None)
+        if weights is None:
+            # we need the weights.
+            weights, = evaluate([self._rule.weight_expression])
+            weights = weights.arr.flatten()
+            self._rule.weights = weights
+
         return FIAT.QuadratureElement(self.cell, ps.points, weights)
 
     def basis_evaluation(self, order, ps, entity=None, coordinate_mapping=None):


### PR DESCRIPTION
This fixes

```
from firedrake import *
from ufl.geometry import QuadratureWeight

mesh = UnitSquareMesh(2, 1, quadrilateral=True)
gdim = mesh.geometric_dimension()
V = FunctionSpace(mesh, "CG", 1)

# scalar Quadrature element
Qse = FiniteElement("Quadrature", mesh.ufl_cell(), degree=2, quad_scheme="default")
Qs = FunctionSpace(mesh, Qse)

# tensor quadrature element
Qte = TensorElement("Quadrature", mesh.ufl_cell(), degree=2, quad_scheme="default", shape=(gdim, gdim))
Qt = FunctionSpace(mesh, Qte)

x = SpatialCoordinate(mesh)[0]
xq = interpolate(x, Qs)
print("Coordinate: ")
print(xq.dat.data_ro)
print("x-coordinates of quadrature points on cell 0: ")
print(xq.dat.data_ro[Qs.cell_node_map().values[0]])

Jinv = JacobianInverse(mesh)
Jdet = JacobianDeterminant(mesh)
w = QuadratureWeight(mesh)
G = dot(Jinv.T, Jinv) * Jdet
Gq = interpolate(G, Qt)
print(Gq.dat.data_ro)
print("G on quadrature points on cell 0: ")
print(Gq.dat.data_ro[Qt.cell_node_map().values[0]])
```

Without this branch, the test gives backtraces like

```
Traceback (most recent call last):
  File "interpolate-G.py", line 17, in <module>
    xq = interpolate(x, Qs)
  File "/scratch/farrellp/install-scripts/firedrake/firedrake-dev-20200903-mpich/src/firedrake/firedrake/interpolation.py", line 50, in interpolate
    return Interpolator(expr, V, subset=subset, access=access).interpolate()
  File "/scratch/farrellp/install-scripts/firedrake/firedrake-dev-20200903-mpich/src/firedrake/firedrake/interpolation.py", line 73, in __init__
    self.callable, arguments = make_interpolator(expr, V, subset, access)
  File "/scratch/farrellp/install-scripts/firedrake/firedrake-dev-20200903-mpich/src/firedrake/firedrake/interpolation.py", line 189, in make_interpolator
    loops.extend(_interpolator(V, tensor, expr, subset, arguments, access))
  File "<decorator-gen-25>", line 2, in _interpolator
  File "/scratch/farrellp/install-scripts/firedrake/firedrake-dev-20200903-mpich/src/firedrake/firedrake/utils.py", line 73, in wrapper
    return f(*args, **kwargs)
  File "/scratch/farrellp/install-scripts/firedrake/firedrake-dev-20200903-mpich/src/firedrake/firedrake/interpolation.py", line 237, in _interpolator
    coffee=False)
  File "/scratch/farrellp/install-scripts/firedrake/firedrake-dev-20200903-mpich/src/tsfc/tsfc/driver.py", line 374, in compile_expression_dual_evaluation
    quad_rule = QuadratureRule(point_set, to_element._weights)
  File "/scratch/farrellp/install-scripts/firedrake/firedrake-dev-20200903-mpich/src/FInAT/finat/quadrature.py", line 80, in __init__
    assert len(point_set.points) == len(weights)
TypeError: len() of unsized object

```

Relevant to p-multigrid, @pbrubeck.