### PR TITLE
Update package names for installation CI

### DIFF
--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,2 +1,2 @@
-git+https://github.com/firedrakeproject/fiat.git#egg=fiat
+git+https://github.com/firedrakeproject/fiat.git#egg=fenics-fiat
 git+https://github.com/firedrakeproject/tsfc.git#egg=tsfc


### PR DESCRIPTION
Update fiat package name to fenics-fiat. Aims to fix this problem during install on CI:

```
ERROR: Could not find a version that satisfies the requirement fiat (unavailable)
ERROR: No matching distribution found for fiat (unavailable)
Error: Process completed with exit code 1.
```

Similar to https://github.com/firedrakeproject/tsfc/pull/238