### PR TITLE
Runtime point set for use with QuadratureElement

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -25,7 +25,7 @@ from .enriched import EnrichedElement  # noqa: F401
 from .hdivcurl import HCurlElement, HDivElement  # noqa: F401
 from .mixed import MixedElement  # noqa: F401
 from .nodal_enriched import NodalEnrichedElement  # noqa: 401
-from .quadrature_element import QuadratureElement  # noqa: F401
+from .quadrature_element import QuadratureElement, make_quadrature_element  # noqa: F401
 from .restricted import RestrictedElement          # noqa: F401
 from .runtime_tabulated import RuntimeTabulated  # noqa: F401
 from . import quadrature  # noqa: F401

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -18,8 +18,8 @@ class AbstractPointSet(metaclass=ABCMeta):
 
     @abstractproperty
     def points(self):
-        """A flattened numpy array of points with shape
-        (# of points, point dimension)."""
+        """A flattened numpy array of points or ``UnknownPointsArray``
+        object with shape (# of points, point dimension)."""
 
     @property
     def dimension(self):
@@ -41,7 +41,7 @@ class AbstractPointSet(metaclass=ABCMeta):
 class PointSingleton(AbstractPointSet):
     """A point set representing a single point.
 
-    These have a `gem.Literal` expression and no indices."""
+    These have a ``gem.Literal`` expression and no indices."""
 
     def __init__(self, point):
         """Build a PointSingleton from a single point.
@@ -64,6 +64,60 @@ class PointSingleton(AbstractPointSet):
     @cached_property
     def expression(self):
         return gem.Literal(self.point)
+
+
+class UnknownPointsArray():
+    """A placeholder for a set of unknown points with appropriate length
+    and size but without indexable values. For use with
+    :class:`AbstractPointSet`s whose points are not known at compile
+    time."""
+    def __init__(self, shape):
+        """
+        :arg shape: The shape of the unknown set of N points of shape
+            (N, D) where D is the dimension of each point.
+        """
+        assert len(shape) == 2
+        self.shape = shape
+
+    def __len__(self):
+        return self.shape[0]
+
+
+class UnknownPointSet(AbstractPointSet):
+    """A point set representing a vector of points with unknown
+    locations but known ``gem.Variable`` expression.
+
+    The ``.points`` property is an `UnknownPointsArray` object with
+    shape (N, D) where N is the number of points and D is their
+    dimension.
+
+    The ``.expression`` property is a derived `gem.partial_indexed` with
+    shape (D,) and free indices for the points N."""
+
+    def __init__(self, points_expr):
+        """Build a PointSingleton from a gem expression for a single point.
+
+        :arg points_expr: A ``gem.Variable`` expression representing a
+            vector of N points in D dimensions. Should have shape (N, D)
+            and no free indices. For runtime tabulation the variable
+            name should begin with \'rt_:\'."""
+        assert isinstance(points_expr, gem.Variable)
+        assert points_expr.free_indices == ()
+        assert len(points_expr.shape) == 2
+        self._points_expr = points_expr
+
+    @cached_property
+    def points(self):
+        return UnknownPointsArray(self._points_expr.shape)
+
+    @cached_property
+    def indices(self):
+        N, _ = self._points_expr.shape
+        return (gem.Index(extent=N),)
+
+    @cached_property
+    def expression(self):
+        return gem.partial_indexed(self._points_expr, self.indices)
 
 
 class PointSet(AbstractPointSet):

--- a/finat/point_set.py
+++ b/finat/point_set.py
@@ -53,15 +53,13 @@ class PointSingleton(AbstractPointSet):
         assert len(point.shape) == 1
         self.point = point
 
-    @property
+    @cached_property
     def points(self):
         # Make sure we conform to the expected (# of points, point dimension)
         # shape
         return self.point.reshape(1, -1)
 
-    @property
-    def indices(self):
-        return ()
+    indices = ()
 
     @cached_property
     def expression(self):

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -23,7 +23,7 @@ def make_quadrature(ref_el, degree, scheme="default"):
     Gauss scheme on simplices.  On tensor-product cells, it is a
     tensor-product quadrature rule of the subcells.
 
-    :arg cell: The FIAT cell to create the quadrature for.
+    :arg ref_el: The FIAT cell to create the quadrature for.
     :arg degree: The degree of polynomial that the rule should
         integrate exactly.
     """

--- a/finat/quadrature_element.py
+++ b/finat/quadrature_element.py
@@ -12,17 +12,38 @@ from finat.finiteelementbase import FiniteElementBase
 from finat.quadrature import make_quadrature, AbstractQuadratureRule
 
 
+def make_quadrature_element(fiat_ref_cell, degree, scheme="default"):
+    """Construct a :class:`QuadratureElement` from a given a reference
+    element, degree and scheme.
+
+    :param fiat_ref_cell: The FIAT reference cell to build the
+        :class:`QuadratureElement` on.
+    :param degree: The degree of polynomial that the rule should
+        integrate exactly.
+    :param scheme: The quadrature scheme to use - e.g. "default",
+        "canonical" or "KMV".
+    :returns: The appropriate :class:`QuadratureElement`
+    """
+    rule = make_quadrature(fiat_ref_cell, degree, scheme)
+    return QuadratureElement(fiat_ref_cell, rule)
+
+
 class QuadratureElement(FiniteElementBase):
     """A set of quadrature points pretending to be a finite element."""
 
-    def __init__(self, cell, degree, scheme="default", rule=None):
-        self.cell = cell
-        if rule is not None:
-            if not isinstance(rule, AbstractQuadratureRule):
-                raise TypeError("rule is not an AbstractQuadratureRule")
-            self._rule = rule
-        else:
-            self._rule = make_quadrature(cell, degree, scheme)
+    def __init__(self, fiat_ref_cell, rule):
+        """Construct a :class:`QuadratureElement`.
+
+        :param fiat_ref_cell: The FIAT reference cell to build the
+            :class:`QuadratureElement` on
+        :param rule: A :class:`AbstractQuadratureRule` to use
+        """
+        self.cell = fiat_ref_cell
+        if not isinstance(rule, AbstractQuadratureRule):
+            raise TypeError("rule is not an AbstractQuadratureRule")
+        if fiat_ref_cell.get_dimension() != rule.point_set.dimension:
+            raise ValueError("Cell dimension does not match rule's point set dimension")
+        self._rule = rule
 
     @cached_property
     def cell(self):

--- a/finat/quadrature_element.py
+++ b/finat/quadrature_element.py
@@ -9,15 +9,20 @@ from gem.interpreter import evaluate
 from gem.utils import cached_property
 
 from finat.finiteelementbase import FiniteElementBase
-from finat.quadrature import make_quadrature
+from finat.quadrature import make_quadrature, AbstractQuadratureRule
 
 
 class QuadratureElement(FiniteElementBase):
     """A set of quadrature points pretending to be a finite element."""
 
-    def __init__(self, cell, degree, scheme="default"):
+    def __init__(self, cell, degree, scheme="default", rule=None):
         self.cell = cell
-        self._rule = make_quadrature(cell, degree, scheme)
+        if rule is not None:
+            if not isinstance(rule, AbstractQuadratureRule):
+                raise TypeError("rule is not an AbstractQuadratureRule")
+            self._rule = rule
+        else:
+            self._rule = make_quadrature(cell, degree, scheme)
 
     @cached_property
     def cell(self):

--- a/finat/quadrature_element.py
+++ b/finat/quadrature_element.py
@@ -1,3 +1,4 @@
+from finat.point_set import PointSet, UnknownPointSet
 from functools import reduce
 
 import numpy
@@ -83,6 +84,12 @@ class QuadratureElement(FiniteElementBase):
     @cached_property
     def fiat_equivalent(self):
         ps = self._rule.point_set
+        if isinstance(ps, UnknownPointSet):
+            # This really should raise a ValueError since there ought not to be
+            # a FIAT equivalent where the points are unknown.
+            # For compatibility until FInAT dual evaluation is done we pass an
+            # array of NaNs of correct shape as the points.
+            ps = PointSet(numpy.full(ps.points.shape, numpy.nan))
         weights = getattr(self._rule, 'weights', None)
         if weights is None:
             # we need the weights.


### PR DESCRIPTION
Adds a new `UnknownPointSingleton` which represents a single point which is specified at run time. 

`UnknownPointSingleton`s are typically intended for use as the point set in the rule of a `QuadratureElement`: the `QuadratureElement` acts as a target element on the reference cell when performing dual basis evaluation on some other element for run time specified points. A typical use case is when performing dual evaluation across different elements on different domains. By only specifying an `UnknownPointSingleton` (rather than a full `UnknownPointSet`), only runtime evaluation at single points can be supported at present. 

The `QuadratureElement` API has been suitably adjusted and a compatibility function added.

These changes are needed to allow interpolation from an arbitrary function function space onto a P0DG function space on a Firedrake `VertexOnlyMesh`

This replaces #66 and sits on top of master, avoiding dependency on #57 (dual evaluation which needs lots of work).

Linked PRs
 - https://github.com/firedrakeproject/firedrake/pull/2059
 - https://github.com/firedrakeproject/tsfc/pull/247

Generated Issues
 - ~#83~
 - #84 

todo:
 - [x] ~Add comment about array of NaNs being a hack to support FIAT dual evaluation and that, when FInAT dual evaluation is implemented, we will raise an exception when asking for the `points` of an `UnknownPointSingleton` and will disallow creation of a `fiat_equivalent` for a quadrature element which uses an `UnknownPointSingleton`~ See dbc58367796bc6ec4605f65e475946f4a58b423a