### PR TITLE
Dual for hdiv/hcurl element wrappers

### DIFF
--- a/finat/hdivcurl.py
+++ b/finat/hdivcurl.py
@@ -74,6 +74,19 @@ class WrapperElementBase(FiniteElementBase):
         core_eval = self.wrappee.point_evaluation(order, refcoords, entity)
         return self._transform_evaluation(core_eval)
 
+    @property
+    def dual_basis(self):
+        Q, x = self.wrappee.dual_basis
+        beta = self.get_indices()
+        zeta = self.get_value_indices()
+        # Index out the basis indices from wrapee's Q, to get
+        # something of wrappee.value_shape, then promote to new shape
+        # with the same transform as done for basis evaluation
+        Q = gem.ListTensor(self.transform(gem.partial_indexed(Q, beta)))
+        # Finally wrap up Q in shape again (now with some extra
+        # value_shape indices)
+        return gem.ComponentTensor(Q[zeta], beta + zeta), x
+
 
 class HDivElement(WrapperElementBase):
     """H(div) wrapper element for tensor product elements."""

--- a/finat/tensor_product.py
+++ b/finat/tensor_product.py
@@ -171,9 +171,16 @@ class TensorProductElement(FiniteElementBase):
         # Outer product the dual bases of the factors
         qs, pss = zip(*(factor.dual_basis for factor in self.factors))
         ps = TensorPointSet(pss)
-        qis = tuple(q[gem.indices(len(q.shape))] for q in qs)
-        indices = tuple(chain(*(q.index_ordering() for q in qis)))
-        Q = gem.ComponentTensor(reduce(gem.Product, qis), indices)
+        # Naming as _merge_evaluations above
+        alphas = [factor.get_indices() for factor in self.factors]
+        zetas = [factor.get_value_indices() for factor in self.factors]
+        # Index the factors by so that we can reshape into index-shape
+        # followed by value-shape
+        qis = [q[alpha + zeta] for q, alpha, zeta in zip(qs, alphas, zetas)]
+        Q = gem.ComponentTensor(
+            reduce(gem.Product, qis),
+            tuple(chain(*(alphas + zetas)))
+        )
         return Q, ps
 
     @cached_property


### PR DESCRIPTION
Progress towards having duals for all finat element modifiers. The big missing one now is `EnrichedElement`.

This change also showed up a bug in the implementation of the dual for tensor product elements (if any of the factors had value_shape).