### PR TITLE
changed kmv to mlt

### DIFF
--- a/finat/__init__.py
+++ b/finat/__init__.py
@@ -9,7 +9,7 @@ from .fiat_elements import BrezziDouglasMarini, BrezziDouglasFortinMarini  # noq
 from .fiat_elements import Nedelec, NedelecSecondKind, RaviartThomas  # noqa: F401
 from .fiat_elements import HellanHerrmannJohnson, Regge  # noqa: F401
 from .fiat_elements import FacetBubble  # noqa: F401
-from .fiat_elements import KongMulderVeldhuizen  # noqa: F401
+from .fiat_elements import MassLumpedTriangular  # noqa: F401
 from .argyris import Argyris            # noqa: F401
 from .bell import Bell                  # noqa: F401
 from .hermite import Hermite            # noqa: F401

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -419,9 +419,9 @@ class Lagrange(ScalarFiatElement):
         super(Lagrange, self).__init__(FIAT.Lagrange(cell, degree))
 
 
-class KongMulderVeldhuizen(ScalarFiatElement):
+class MassLumpedTriangular(ScalarFiatElement):
     def __init__(self, cell, degree):
-        super(KongMulderVeldhuizen, self).__init__(FIAT.KongMulderVeldhuizen(cell, degree))
+        super(MassLumpedTriangular, self).__init__(FIAT.MassLumpedTriangular(cell, degree))
         if Citations is not None:
             Citations().register("Chin1999higher")
             Citations().register("Geevers2018new")


### PR DESCRIPTION
This PR was made just to rename the KMV elements. KMV is a bit of a misnomer, since the last name of the first author of the cited paper is actually Chin-Joe-Kong (https://link.springer.com/article/10.1023/A:1004420829610).

Also, since this type of higher order triangular mass lumped triangular elements for the wave equation has been the subject of many papers getting the name of every researcher involved would be quite a list, therefore, I propose we just follow the nomenclature from the articles the used quadrature points come from and call them MLT.

Articles:

    Higher-order triangular and tetrahedral finite elements with mass
    lumping for solving the wave equation
    M. J. S. CHIN-JOE-KONG, W. A. MULDER and M. VAN VELDHUIZEN

    Higher-order Mass-lumped Finite Elements for the Wave Equation
    W.A. MULDER

    New Higher-order Mass-lumped Tetrahedral Elements
    S. GEEVERS, W.A. MULDER, AND J.J.W. VAN DER VEGT

This PR is also associated with PRs in UFL, TSFC, FIAT and Firedrake.