### PR TITLE
Tabulate Ciarlet generically

### DIFF
--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -3,7 +3,6 @@ import sympy as sp
 from functools import singledispatch
 
 import FIAT
-from FIAT.polynomial_set import mis, form_matrix_product
 
 import gem
 from gem.utils import cached_property
@@ -314,66 +313,6 @@ def point_evaluation_generic(fiat_element, order, refcoords, entity):
         else:
             expr, = exprs
             result[alpha] = expr
-    return result
-
-
-@point_evaluation.register(FIAT.CiarletElement)
-def point_evaluation_ciarlet(fiat_element, order, refcoords, entity):
-    # Coordinates on the reference entity (SymPy)
-    esd, = refcoords.shape
-    Xi = sp.symbols('X Y Z')[:esd]
-
-    # Coordinates on the reference cell
-    cell = fiat_element.get_reference_element()
-    X = cell.get_entity_transform(*entity)(Xi)
-
-    # Evaluate expansion set at SymPy point
-    poly_set = fiat_element.get_nodal_basis()
-    degree = poly_set.get_embedded_degree()
-    base_values = poly_set.get_expansion_set().tabulate(degree, [X])
-    m = len(base_values)
-    assert base_values.shape == (m, 1)
-    base_values_sympy = np.array(list(base_values.flat))
-
-    # Find constant polynomials
-    def is_const(expr):
-        try:
-            float(expr)
-            return True
-        except TypeError:
-            return False
-    const_mask = np.array(list(map(is_const, base_values_sympy)))
-
-    # Convert SymPy expression to GEM
-    mapper = gem.node.Memoizer(sympy2gem)
-    mapper.bindings = {s: gem.Indexed(refcoords, (i,))
-                       for i, s in enumerate(Xi)}
-    base_values = gem.ListTensor(list(map(mapper, base_values.flat)))
-
-    # Populate result dict, creating precomputed coefficient
-    # matrices for each derivative tuple.
-    result = {}
-    for i in range(order + 1):
-        for alpha in mis(cell.get_spatial_dimension(), i):
-            D = form_matrix_product(poly_set.get_dmats(), alpha)
-            table = np.dot(poly_set.get_coeffs(), np.transpose(D))
-            assert table.shape[-1] == m
-            zerocols = np.isclose(abs(table).max(axis=tuple(range(table.ndim - 1))), 0.0)
-            if all(np.logical_or(const_mask, zerocols)):
-                # Casting is safe by assertion of is_const
-                vals = base_values_sympy[const_mask].astype(np.float64)
-                result[alpha] = gem.Literal(table[..., const_mask].dot(vals))
-            else:
-                beta = tuple(gem.Index() for s in table.shape[:-1])
-                k = gem.Index()
-                result[alpha] = gem.ComponentTensor(
-                    gem.IndexSum(
-                        gem.Product(gem.Indexed(gem.Literal(table), beta + (k,)),
-                                    gem.Indexed(base_values, (k,))),
-                        (k,)
-                    ),
-                    beta
-                )
     return result
 
 

--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -1,6 +1,5 @@
 import numpy as np
 import sympy as sp
-from functools import singledispatch
 
 import FIAT
 
@@ -175,7 +174,6 @@ class FiatElement(FiniteElementBase):
         esd = self.cell.construct_subelement(entity_dim).get_spatial_dimension()
         assert isinstance(refcoords, gem.Node) and refcoords.shape == (esd,)
 
-        # Dispatch on FIAT element class
         return point_evaluation(self._element, order, refcoords, (entity_dim, entity_i))
 
     @cached_property
@@ -267,13 +265,7 @@ class FiatElement(FiniteElementBase):
             return result
 
 
-@singledispatch
 def point_evaluation(fiat_element, order, refcoords, entity):
-    raise AssertionError("FIAT element expected!")
-
-
-@point_evaluation.register(FIAT.FiniteElement)
-def point_evaluation_generic(fiat_element, order, refcoords, entity):
     # Coordinates on the reference entity (SymPy)
     esd, = refcoords.shape
     Xi = sp.symbols('X Y Z')[:esd]

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,3 +1,3 @@
-git+https://github.com/firedrakeproject/fiat.git#egg=fenics-fiat
+git+https://github.com/firedrakeproject/fiat.git#egg=fenics-fiat@pbrubeck/simplify-lagrange
 git+https://github.com/firedrakeproject/tsfc.git#egg=tsfc
 git+https://github.com/firedrakeproject/ufl.git#egg=fenics-ufl

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,3 +1,3 @@
-git+https://github.com/firedrakeproject/fiat.git@pbrubeck/simplify-lagrange
+git+https://github.com/firedrakeproject/fiat.git#egg=fenics-fiat
 git+https://github.com/firedrakeproject/tsfc.git#egg=tsfc
 git+https://github.com/firedrakeproject/ufl.git#egg=fenics-ufl

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,3 +1,3 @@
-git+https://github.com/firedrakeproject/fiat.git#egg=fenics-fiat@pbrubeck/simplify-lagrange
+git+https://github.com/firedrakeproject/fiat.git@pbrubeck/simplify-lagrange
 git+https://github.com/firedrakeproject/tsfc.git#egg=tsfc
 git+https://github.com/firedrakeproject/ufl.git#egg=fenics-ufl


### PR DESCRIPTION
It seems that we did not really need a special case for point evaluation of Ciarlet elements. 
Instead of directly tabulating an element on a sympy Variable, we were evaluating the expansion set and manipulating the expansion coefficients trying to simplify tabulations that result in constants, e. g. second derivatives of Lagrange(2). Operating at the expansion coefficient level will only simplify constants when the constant function is a member of the expansion set, which is not true for a LagrangeLineExpansionSet.

It turns out that a special case for Ciarlet is not necessary, as `gem.ListTensor` has constant folding.
https://github.com/firedrakeproject/tsfc/blob/5515b2ae3c19e41bf80f347e7259fe9f5d86a9a2/gem/gem.py#L724


Tests that were failing are passing with this PR and https://github.com/firedrakeproject/fiat/pull/54

fixes #114 while keeping the LagrangeLineExpansionSet