### PR TITLE
Allow embedded_subdegree and embedded_superdegree to handle tuples

### DIFF
--- a/finat/ufl/finiteelement.py
+++ b/finat/ufl/finiteelement.py
@@ -234,3 +234,19 @@ class FiniteElement(FiniteElementBase):
                 None,
                 self.quadrature_scheme(),
                 self.variant())
+
+    @property
+    def embedded_subdegree(self):
+        """Return embedded subdegree."""
+        if isinstance(self.degree(), int):
+            return self.degree()
+        else:
+            return min(self.degree())
+
+    @property
+    def embedded_superdegree(self):
+        """Return embedded superdegree."""
+        if isinstance(self.degree(), int):
+            return self.degree()
+        else:
+            return max(self.degree())


### PR DESCRIPTION
This appears to fix https://github.com/firedrakeproject/firedrake/issues/3251. However, I'm not familiar enough with UFL to be confident that this is the right thing to do. Is it legal for a "base" finite element to have non-integer `degree`?