### PR TITLE
Fix dual basis for singleton weight

### DIFF
--- a/finat/fiat_elements.py
+++ b/finat/fiat_elements.py
@@ -233,7 +233,10 @@ class FiatElement(FiniteElementBase):
             # significantly by building Q in a COO format rather than DOK (i.e.
             # storing coords and associated data in (nonzeros, entries) shaped
             # numpy arrays) to take advantage of numpy multiindexing
-            Qshape = tuple(s + 1 for s in map(max, *Q))
+            if len(Q) == 1:
+                Qshape = tuple(s + 1 for s in tuple(Q)[0])
+            else:
+                Qshape = tuple(s + 1 for s in map(max, *Q))
             Qdense = np.zeros(Qshape, dtype=np.float64)
             for idx, value in Q.items():
                 Qdense[idx] = value


### PR DESCRIPTION
This is a bug that we weren't hitting before. `map(max, *Q)` would break if `Q = {(0, 0): X}`. This occurs when you define DG0 with an IntegralMoment with quadrature degree=0, (which we now hit if variant="integral")