### PR TITLE
Add GLL quadrature scheme

### DIFF
--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -23,16 +23,18 @@ def make_quadrature(ref_el, degree, scheme="default"):
     For low-degree polynomials on triangles (<=25) and tetrahedra (<=15), this
     uses hard-coded rules from Xiao and Gimbutas, otherwise it falls back to a
     collapsed Gauss scheme on simplices.  On tensor-product cells, it is a
-    tensor-product quadrature rule of the subcells.
+    tensor-product Gauss-Lobatto quadrature rule of the subcells.
 
     :arg ref_el: The FIAT cell to create the quadrature for.
     :arg degree: The degree of polynomial that the rule should
-        integrate exactly.
+        integrate exactly. For under-integrated schemes this is
+        the degree of the integrand of the lumped mass matrix,
+        degree=2*k gives a diagonal mass matrix for CG_k.
     :arg scheme: The quadrature scheme. Choose from
         'default' FIAT chooses the scheme as described above,
         'canonical' for the collapsed Gauss scheme,
-        'GLL' for under-integrated spectral collocation mass-lumping (tensor-product cells only),
-        'KMV' for under-integrated Kong-Mulder-Veldhuizen mass-lumping (simplex cells only).
+        'GLL' for under-integrated Gauss-Lobatto-Legendre mass-lumping (tensor-product cells only),
+        'KMV' for under-integrated Kong-Mulder-Veldhuizen mass-lumping (simplices only).
     """
     if ref_el.get_shape() == TENSORPRODUCT:
         try:

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -26,15 +26,13 @@ def make_quadrature(ref_el, degree, scheme="default"):
     tensor-product Gauss-Lobatto quadrature rule of the subcells.
 
     :arg ref_el: The FIAT cell to create the quadrature for.
-    :arg degree: The degree of polynomial that the rule should
-        integrate exactly. For under-integrated schemes this is
-        the degree of the integrand of the lumped mass matrix,
-        degree=2*k gives a diagonal mass matrix for CG_k.
+    :arg degree: The degree of polynomial that the rule should integrate exactly.
     :arg scheme: The quadrature scheme. Choose from
         'default' FIAT chooses the scheme as described above,
         'canonical' for the collapsed Gauss scheme,
-        'GLL' for under-integrated Gauss-Lobatto-Legendre mass-lumping (tensor-product cells only),
-        'KMV' for under-integrated Kong-Mulder-Veldhuizen mass-lumping (simplices only).
+        'GLL' for the Gauss-Lobatto-Legendre scheme (tensor-product cells only),
+            degree=2*k-1 gives a diagonal mass matrix for CG_k,
+        'KMV' for the Kong-Mulder-Veldhuizen scheme (simplices only).
     """
     if ref_el.get_shape() == TENSORPRODUCT:
         try:
@@ -54,10 +52,8 @@ def make_quadrature(ref_el, degree, scheme="default"):
         raise ValueError("Need positive degree, not %d" % degree)
 
     if ref_el.get_shape() == LINE:
-        num_points = (degree + 1 + 1) // 2  # exact integration (GL only)
         if scheme.lower() == "gll":
-            # GLL under-integration / Mass-lumping
-            num_points = max(num_points, 2)  # GLL rule only valid for >= 2 points
+            num_points = 1 + (degree + 1 + 1) // 2
             make_fiat_rule = GaussLobattoLegendreQuadratureLineRule
             make_point_set = GaussLobattoLegendrePointSet
         elif scheme.lower() in ["gl", "default", "canonical"]:
@@ -65,6 +61,7 @@ def make_quadrature(ref_el, degree, scheme="default"):
             # symbolically label it as such, we wish not to risk attaching
             # the wrong label in case FIAT changes.  So we explicitly ask
             # for Gauss-Legendre line quadature.
+            num_points = (degree + 1 + 1) // 2
             make_fiat_rule = GaussLegendreQuadratureLineRule
             make_point_set = GaussLegendrePointSet
         else:

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -31,7 +31,7 @@ def make_quadrature(ref_el, degree, scheme="default"):
         'default' FIAT chooses the scheme as described above,
         'canonical' for the collapsed Gauss scheme,
         'GLL' for the Gauss-Lobatto-Legendre scheme (tensor-product cells only),
-            degree=2*k-1 gives a diagonal mass matrix for CG_k,
+            for CG_k, degree=2*k gets the mass matrix exact, 2*k-1 lumps it,
         'KMV' for the Kong-Mulder-Veldhuizen scheme (simplices only).
     """
     if ref_el.get_shape() == TENSORPRODUCT:

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -7,10 +7,12 @@ import gem
 from gem.utils import cached_property
 
 from FIAT.reference_element import LINE, QUADRILATERAL, TENSORPRODUCT
-from FIAT.quadrature import GaussLegendreQuadratureLineRule
+from FIAT.quadrature import (GaussLegendreQuadratureLineRule,
+                             GaussLobattoLegendreQuadratureLineRule)
 from FIAT.quadrature_schemes import create_quadrature as fiat_scheme
 
-from finat.point_set import PointSet, GaussLegendrePointSet, TensorPointSet
+from finat.point_set import (GaussLegendrePointSet, GaussLobattoLegendrePointSet,
+                             PointSet, TensorPointSet)
 
 
 def make_quadrature(ref_el, degree, scheme="default"):
@@ -26,6 +28,11 @@ def make_quadrature(ref_el, degree, scheme="default"):
     :arg ref_el: The FIAT cell to create the quadrature for.
     :arg degree: The degree of polynomial that the rule should
         integrate exactly.
+    :arg scheme: The quadrature scheme. Choose from
+        'default' FIAT chooses an optimal rule,
+        'canonical' for the Stroud conical product rule (simplex cells only),
+        'GLL' for spectral collocation mass-lumping (tensor-product cells only),
+        'KMV' for mass-lumping (simplex cells only).
     """
     if ref_el.get_shape() == TENSORPRODUCT:
         try:
@@ -45,13 +52,24 @@ def make_quadrature(ref_el, degree, scheme="default"):
         raise ValueError("Need positive degree, not %d" % degree)
 
     if ref_el.get_shape() == LINE:
-        # FIAT uses Gauss-Legendre line quadature, however, since we
-        # symbolically label it as such, we wish not to risk attaching
-        # the wrong label in case FIAT changes.  So we explicitly ask
-        # for Gauss-Legendre line quadature.
-        num_points = (degree + 1 + 1) // 2  # exact integration
-        fiat_rule = GaussLegendreQuadratureLineRule(ref_el, num_points)
-        point_set = GaussLegendrePointSet(fiat_rule.get_points())
+        num_points = (degree + 1 + 1) // 2  # exact integration (GL only)
+        if scheme.lower() == "gll":
+            # GLL under-integration / Mass-lumping
+            num_points = max(num_points, 2)  # GLL rule only valid for >= 2 points
+            make_fiat_rule = GaussLobattoLegendreQuadratureLineRule
+            make_point_set = GaussLobattoLegendrePointSet
+        elif scheme.lower() in ["gl", "default", "canonical"]:
+            # FIAT uses Gauss-Legendre line quadature, however, since we
+            # symbolically label it as such, we wish not to risk attaching
+            # the wrong label in case FIAT changes.  So we explicitly ask
+            # for Gauss-Legendre line quadature.
+            make_fiat_rule = GaussLegendreQuadratureLineRule
+            make_point_set = GaussLegendrePointSet
+        else:
+            raise ValueError(f"Invalid quadrature scheme {scheme}.")
+
+        fiat_rule = make_fiat_rule(ref_el, num_points)
+        point_set = make_point_set(fiat_rule.get_points())
         return QuadratureRule(point_set, fiat_rule.get_weights())
 
     fiat_rule = fiat_scheme(ref_el, degree, scheme)

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -20,19 +20,19 @@ def make_quadrature(ref_el, degree, scheme="default"):
     Generate quadrature rule for given reference element
     that will integrate an polynomial of order 'degree' exactly.
 
-    For low-degree (<=6) polynomials on triangles and tetrahedra, this
-    uses hard-coded rules, otherwise it falls back to a collapsed
-    Gauss scheme on simplices.  On tensor-product cells, it is a
+    For low-degree polynomials on triangles (<=25) and tetrahedra (<=15), this
+    uses hard-coded rules from Xiao and Gimbutas, otherwise it falls back to a
+    collapsed Gauss scheme on simplices.  On tensor-product cells, it is a
     tensor-product quadrature rule of the subcells.
 
     :arg ref_el: The FIAT cell to create the quadrature for.
     :arg degree: The degree of polynomial that the rule should
         integrate exactly.
     :arg scheme: The quadrature scheme. Choose from
-        'default' FIAT chooses an optimal rule,
-        'canonical' for the Stroud conical product rule (simplex cells only),
-        'GLL' for spectral collocation mass-lumping (tensor-product cells only),
-        'KMV' for mass-lumping (simplex cells only).
+        'default' FIAT chooses the scheme as described above,
+        'canonical' for the collapsed Gauss scheme,
+        'GLL' for under-integrated spectral collocation mass-lumping (tensor-product cells only),
+        'KMV' for under-integrated Kong-Mulder-Veldhuizen mass-lumping (simplex cells only).
     """
     if ref_el.get_shape() == TENSORPRODUCT:
         try:


### PR DESCRIPTION
Adding support for tensor product GLL quadrature scheme within `finat.make_quadrature `. Intentionally, this scheme is not exact for integrands of the requested quadrature degree, but here we underintegrate such that we obtain a lumped mass matrix for GLL Lagrange elements if quadrature degree == 2 * degree of the finite element space.

With the extended support for strings in the quadrature scheme metadata (https://github.com/firedrakeproject/tsfc/pull/306), now we can specify the GLL quadrature in a much user-friendly way (as opposed to implementing these tensor product rules directly with FInAT as in https://nbviewer.jupyter.org/github/firedrakeproject/firedrake/blob/master/docs/notebooks/10-sum-factorisation.ipynb).

```
from firedrake import *
mesh = UnitSquareMesh(1, 1, quadrilateral=True)
degree = 3
V = FunctionSpace(mesh, "Q", degree)
A = assemble(inner(TrialFunction(V), TestFunction(V)) * dx(degree=2*degree, scheme="gll"))
A.petscmat.view()

Mat Object: 1 MPI process
  type: seqaij
row 0: (0, 0.0347222)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 1: (0, 0.)  (1, 0.173611)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 2: (0, 0.)  (1, 0.)  (2, 0.00694444)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 3: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.0347222)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 4: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.0347222)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 5: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.00694444)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 6: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.173611)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 7: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.0347222)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 8: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.0347222)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 9: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.173611)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 10: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.00694444)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 11: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.0347222)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.) 
row 12: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.00694444)  (13, 0.)  (14, 0.)  (15, 0.) 
row 13: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.0347222)  (14, 0.)  (15, 0.) 
row 14: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.173611)  (15, 0.) 
row 15: (0, 0.)  (1, 0.)  (2, 0.)  (3, 0.)  (4, 0.)  (5, 0.)  (6, 0.)  (7, 0.)  (8, 0.)  (9, 0.)  (10, 0.)  (11, 0.)  (12, 0.)  (13, 0.)  (14, 0.)  (15, 0.0347222) 

```