### PR TITLE
Create ufl_signature property

### DIFF
--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -89,6 +89,10 @@ class QuadratureRule(AbstractQuadratureRule):
     @cached_property
     def weight_expression(self):
         return gem.Indexed(gem.Literal(self.weights), self.point_set.indices)
+    
+    @property
+    def ufl_signature(self):
+        return type(self).__name__ + str(self._parameters)
 
 
 class TensorProductQuadratureRule(AbstractQuadratureRule):

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -76,9 +76,9 @@ class QuadratureRule(AbstractQuadratureRule):
     """Generic quadrature rule with no internal structure."""
 
     def __init__(self, point_set, weights):
-        weights = numpy.asarray(weights)
-        assert len(point_set.points) == len(weights)
+        assert len(point_set.points) == len(numpy.asarray(weights))
 
+        self._parameters = (point_set, weights)
         self.point_set = point_set
         self.weights = numpy.asarray(weights)
 

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -89,7 +89,7 @@ class QuadratureRule(AbstractQuadratureRule):
     @cached_property
     def weight_expression(self):
         return gem.Indexed(gem.Literal(self.weights), self.point_set.indices)
-    
+
     @property
     def ufl_signature(self):
         return type(self).__name__ + str(self._parameters)

--- a/finat/quadrature.py
+++ b/finat/quadrature.py
@@ -94,7 +94,6 @@ class QuadratureRule(AbstractQuadratureRule):
     def ufl_signature(self):
         return type(self).__name__ + str(self._parameters)
 
-
 class TensorProductQuadratureRule(AbstractQuadratureRule):
     """Quadrature rule which is a tensor product of other rules."""
 


### PR DESCRIPTION
This PR addresses an issue with `ufl` warnings that can be disruptive for users. The warnings arise when users define code like:

```python
quad_rule = finat.quadrature.make_quadrature(V.finat_element.cell, V.ufl_element().degree(), "KMV")
time_term = (1 / (c * c)) * (u - 2.0 * u_n + u_nm1) / Constant(dt**2) * v * dx(scheme=quad_rule)
```

resulting in the following warnings:

```
/Users/ddolci/tes_fire_install/firedrake_test/src/ufl/ufl/utils/sorting.py:86: UserWarning: Applying str() to a metadata value of type QuadratureRule, don't know if this is safe.
  warnings.warn(f"Applying str() to a metadata value of type {type(value).__name__}, "
/Users/ddolci/tes_fire_install/firedrake_test/src/ufl/ufl/utils/sorting.py:86: UserWarning: Applying str() to a metadata value of type QuadratureRule, don't know if this is safe.
  warnings.warn(f"Applying str() to a metadata value of type {type(value).__name__}, 
```

This PR introduces a `Quadrature.ufl_signature` property to resolve these warnings.