### PR TITLE
Use md5 to hash FiniteElementBase

### DIFF
--- a/finat/ufl/finiteelementbase.py
+++ b/finat/ufl/finiteelementbase.py
@@ -85,7 +85,7 @@ class FiniteElementBase(AbstractFiniteElement):
 
     def __hash__(self):
         """Compute hash code for insertion in hashmaps."""
-        return int.from_bytes(md5(self._ufl_hash_data_().encode()).digest())
+        return int.from_bytes(md5(self._ufl_hash_data_().encode()).digest(), byteorder='big')
 
     def __eq__(self, other):
         """Compute element equality for insertion in hashmaps."""

--- a/finat/ufl/finiteelementbase.py
+++ b/finat/ufl/finiteelementbase.py
@@ -12,6 +12,7 @@
 # Modified by Matthew Scroggs, 2023
 
 from abc import abstractmethod, abstractproperty
+from hashlib import md5
 
 from ufl import pullback
 from ufl.cell import AbstractCell, as_cell
@@ -84,7 +85,7 @@ class FiniteElementBase(AbstractFiniteElement):
 
     def __hash__(self):
         """Compute hash code for insertion in hashmaps."""
-        return hash(self._ufl_hash_data_())
+        return int.from_bytes(md5(self._ufl_hash_data_().encode()).digest())
 
     def __eq__(self, other):
         """Compute element equality for insertion in hashmaps."""

--- a/test/test_hash.py
+++ b/test/test_hash.py
@@ -14,6 +14,7 @@ def test_same_hash():
     same_cg = finat.ufl.finiteelement.FiniteElement("Lagrange", ufl.cell.Cell("triangle"), 1)
     assert hash(cg) == hash(same_cg)
 
+
 def test_different_hash():
     """ Two different elements should have different hashes.
     """
@@ -21,12 +22,14 @@ def test_different_hash():
     dg = finat.ufl.finiteelement.FiniteElement("DG", ufl.cell.Cell("triangle"), 2)
     assert hash(cg) != hash(dg)
 
+
 def test_variant_hashes_different():
     """ Different variants of the same element should have different hashes.
     """
     dg = finat.ufl.finiteelement.FiniteElement("DG", ufl.cell.Cell("triangle"), 2)
     dg_gll = finat.ufl.finiteelement.FiniteElement("DG", ufl.cell.Cell("triangle"), 2, variant="gll")
     assert hash(dg) != hash(dg_gll)
+
 
 def test_persistent_hash(tmp_path):
     """ Hashes should be the same across Python invocations.

--- a/test/test_hash.py
+++ b/test/test_hash.py
@@ -1,0 +1,50 @@
+import os
+import sys
+import subprocess
+import textwrap
+
+import ufl
+import finat.ufl
+
+
+def test_same_hash():
+    """ The same element created twice should have the same hash.
+    """
+    cg = finat.ufl.finiteelement.FiniteElement("Lagrange", ufl.cell.Cell("triangle"), 1)
+    same_cg = finat.ufl.finiteelement.FiniteElement("Lagrange", ufl.cell.Cell("triangle"), 1)
+    assert hash(cg) == hash(same_cg)
+
+def test_different_hash():
+    """ Two different elements should have different hashes.
+    """
+    cg = finat.ufl.finiteelement.FiniteElement("Lagrange", ufl.cell.Cell("triangle"), 1)
+    dg = finat.ufl.finiteelement.FiniteElement("DG", ufl.cell.Cell("triangle"), 2)
+    assert hash(cg) != hash(dg)
+
+def test_variant_hashes_different():
+    """ Different variants of the same element should have different hashes.
+    """
+    dg = finat.ufl.finiteelement.FiniteElement("DG", ufl.cell.Cell("triangle"), 2)
+    dg_gll = finat.ufl.finiteelement.FiniteElement("DG", ufl.cell.Cell("triangle"), 2, variant="gll")
+    assert hash(dg) != hash(dg_gll)
+
+def test_persistent_hash(tmp_path):
+    """ Hashes should be the same across Python invocations.
+    """
+    filename = "print_hash.py"
+    code = textwrap.dedent("""\
+        import ufl
+        import finat.ufl
+
+        dg = finat.ufl.finiteelement.FiniteElement("RT", ufl.cell.Cell("triangle"), 1)
+        print(hash(dg))
+        """)
+    filepath = tmp_path.joinpath(filename)
+    with open(filepath, "w") as fh:
+        fh.write(code)
+
+    output1 = subprocess.run([sys.executable, filepath], capture_output=True)
+    assert output1.returncode == os.EX_OK
+    output2 = subprocess.run([sys.executable, filepath], capture_output=True)
+    assert output2.returncode == os.EX_OK
+    assert output1.stdout == output2.stdout


### PR DESCRIPTION
The current implementation produces a different hash for different Python invocations. This means the value cannot safely be used for a (persistent) disk cache.

The new implementation replaces the inbuilt Python `hash` with `md5`, which produces the same result across invocations.

Someone with better knowledge of FInAT should double check that all relevant data is encoded in `self._ufl_hash_data_()` , which I believe is just the repr of whatever the derived object is.